### PR TITLE
브랜드,상품,재고 단위 테스트

### DIFF
--- a/apps/commerce-api/docs/desigin/03-class-diagrams.md
+++ b/apps/commerce-api/docs/desigin/03-class-diagrams.md
@@ -112,7 +112,7 @@ class Stock {
 class ProductStock {
     <<Embedded>>
     - Long stock
-    + decrease(Long stock): long
+    + decrease(Long stock): ProductStock
 }
 
 Stock --> ProductStock : Vo

--- a/apps/commerce-api/docs/desigin/03-class-diagrams.md
+++ b/apps/commerce-api/docs/desigin/03-class-diagrams.md
@@ -50,17 +50,22 @@ class Like {
 class Brand {
     - Long id
     - BrandName name
-    - List<Product> products
+    - Products products
     - LocalDateTime createdAt
     - LocalDateTime updatedAt
     - LocalDateTime deletedAt
-  
-    + add(productId: Long, name: ProductName): void 
 }
 
 class BrandName {
     <<Embedded>>
     - String brandName
+}
+
+class Products {
+    <<Embedded>>
+    - List<Product> products
+    
+    + add(Product:prdocut): void
 }
 
 Brand --> BrandName : Vo
@@ -82,7 +87,13 @@ class ProductName {
     - String productName
 }
 
+class ProductPrice {
+    <<Embedded>>
+    - BigInteger price
+}
+
 Product --> ProductName : Vo
+Product --> ProductPrice : Vo
 
 %% 재고
 class Stock { 

--- a/apps/commerce-api/docs/desigin/03-class-diagrams.md
+++ b/apps/commerce-api/docs/desigin/03-class-diagrams.md
@@ -76,6 +76,7 @@ class Product {
     - Long id
     - ProductName name
     - ProductPrice price
+    - Stock stock
     - String description
     - LocalDateTime createdAt
     - LocalDateTime updatedAt
@@ -94,11 +95,13 @@ class ProductPrice {
 
 Product --> ProductName : Vo
 Product --> ProductPrice : Vo
+Product --> Stock : 소유
 
 %% 재고
 class Stock { 
  - Long id
- - Product product
+ - Long productId
+ - Long stock
  - ProductStock stock
  - LocalDateTime createdAt
  - LocalDateTime updatedAt
@@ -109,7 +112,7 @@ class Stock {
 class ProductStock {
     <<Embedded>>
     - Long stock
-    + decrease(Product prduct, ProductStock prductStock): long
+    + decrease(Long stock): long
 }
 
 Stock --> ProductStock : Vo

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.brand.embeded.BrandName;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Table(name = "brand")
+public class Brand extends BaseEntity {
+
+  private String memberId;
+
+  @Embedded
+  private BrandName name;
+
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/embeded/BrandName.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/embeded/BrandName.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.brand.embeded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class BrandName {
+  @Column(nullable = false, unique = true, length = 50)
+  private String name;
+
+  protected BrandName() {
+  }
+
+  private BrandName(String name) {
+    this.name = name;
+  }
+
+  public static BrandName of(String name) {
+    return new BrandName(name);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/embeded/Products.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/embeded/Products.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.brand.embeded;
+
+import com.loopers.domain.product.Product;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class Products {
+  @OneToMany(mappedBy = "brandId")
+  private List<Product> products;
+
+  protected Products() {
+  }
+
+  private Products(List<Product> products) {
+    this.products = products;
+  }
+
+  public static Products of(List<Product> products) {
+    return new Products(products);
+  }
+
+  public void add(Product product) {
+    this.products.add(product);
+  }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/embeded/Products.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/embeded/Products.java
@@ -3,6 +3,7 @@ package com.loopers.domain.brand.embeded;
 import com.loopers.domain.product.Product;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
@@ -17,6 +18,10 @@ public class Products {
 
   private Products(List<Product> products) {
     this.products = products;
+  }
+
+  public static Products of() {
+    return new Products(new ArrayList<>());
   }
 
   public static Products of(List<Product> products) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -9,13 +9,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.math.BigInteger;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 @Table(name = "product")
 public class Product extends BaseEntity {
@@ -26,4 +24,11 @@ public class Product extends BaseEntity {
   private ProductPrice price;
   @Column(columnDefinition = "TEXT")
   private String description;
+
+  public Product(Long brandId, String name, BigInteger price, String description) {
+    this.brandId = brandId;
+    this.name = ProductName.of(name);
+    this.price = ProductPrice.of(price);
+    this.description = description;
+  }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -1,15 +1,13 @@
-package com.loopers.domain.brand;
+package com.loopers.domain.product;
 
 import com.loopers.domain.BaseEntity;
-import com.loopers.domain.brand.embeded.BrandName;
-import com.loopers.domain.brand.embeded.Products;
-import com.loopers.domain.product.Product;
+import com.loopers.domain.product.embeded.ProductName;
+import com.loopers.domain.product.embeded.ProductPrice;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.List;
+import java.math.BigInteger;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,16 +17,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@Table(name = "brand")
-public class Brand extends BaseEntity {
-
-  private String memberId;
-
+@Table(name = "product")
+public class Product extends BaseEntity {
+  private Long brandId;
   @Embedded
-  private Products products;
-
+  private ProductName name;
   @Embedded
-  private BrandName name;
-
+  private ProductPrice price;
+  @Column(columnDefinition = "TEXT")
+  private String description;
 }
-

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/embeded/ProductName.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/embeded/ProductName.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.product.embeded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class ProductName {
+  @Column(nullable = false, unique = true, length = 100)
+  private String name;
+
+  public ProductName() {
+  }
+
+  public static ProductName of(String name) {
+    return new ProductName(name);
+  }
+  private ProductName(String name) {
+    this.name = name;
+  }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/embeded/ProductPrice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/embeded/ProductPrice.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.product.embeded;
+
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class ProductPrice {
+  private BigDecimal price;
+
+  public ProductPrice() {
+  }
+
+  private ProductPrice(BigDecimal price) {
+    this.price = price;
+  }
+
+  public ProductPrice of(BigDecimal price) {
+    return new ProductPrice(price);
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/embeded/ProductPrice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/embeded/ProductPrice.java
@@ -1,5 +1,7 @@
 package com.loopers.domain.product.embeded;
 
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Embeddable;
 import java.math.BigInteger;
 import lombok.Getter;
@@ -17,6 +19,13 @@ public class ProductPrice {
   }
 
   public static ProductPrice of(BigInteger price) {
+    validate(price);
     return new ProductPrice(price);
+  }
+
+  private static void validate(BigInteger price) {
+    if (price.compareTo(BigInteger.ZERO) < 0) {
+      throw new CoreException(ErrorType.BAD_REQUEST, "상품의 각겨은 음수로 책정할 수 없습니다.");
+    }
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/embeded/ProductPrice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/embeded/ProductPrice.java
@@ -1,22 +1,22 @@
 package com.loopers.domain.product.embeded;
 
 import jakarta.persistence.Embeddable;
-import java.math.BigDecimal;
+import java.math.BigInteger;
 import lombok.Getter;
 
 @Embeddable
 @Getter
 public class ProductPrice {
-  private BigDecimal price;
+  private BigInteger price;
 
   public ProductPrice() {
   }
 
-  private ProductPrice(BigDecimal price) {
+  private ProductPrice(BigInteger price) {
     this.price = price;
   }
 
-  public ProductPrice of(BigDecimal price) {
+  public static ProductPrice of(BigInteger price) {
     return new ProductPrice(price);
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/stock/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/stock/Stock.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.product.stock;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.product.stock.embeded.ProductStock;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "stock")
+public class Stock extends BaseEntity {
+  private Long productId;
+  @Embedded
+  private ProductStock stock;
+
+  public Stock(Long productId, Long stock) {
+    this.productId = productId;
+    this.stock = ProductStock.of(stock);
+  }
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/stock/embeded/ProductStock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/stock/embeded/ProductStock.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.product.stock.embeded;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+public class ProductStock {
+  private Long stock;
+
+  protected ProductStock() {
+  }
+
+  private ProductStock(Long stock) {
+    validate(stock);
+    this.stock = stock;
+  }
+
+  public static ProductStock of(Long stock) {
+    return new ProductStock(stock);
+  }
+
+  public ProductStock decrease(long stock) {
+    return new ProductStock(this.stock - stock);
+  }
+
+  void validate(long stock) {
+    if(stock < 0) {
+      throw new CoreException(ErrorType.BAD_REQUEST, "재고는 0미만일 수 없습니다.");
+    }
+  }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/stock/embeded/ProductStock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/stock/embeded/ProductStock.java
@@ -25,6 +25,9 @@ public class ProductStock {
   }
 
   public ProductStock decrease(long stock) {
+    if(stock < 0) {
+      throw new CoreException(ErrorType.BAD_REQUEST, "음수로 재고 차감은 불가합니다.");
+    }
     return new ProductStock(this.stock - stock);
   }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandModelTest.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.brand.embeded.Products;
+import com.loopers.domain.product.Product;
+import java.math.BigInteger;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class BrandModelTest {
+
+  @DisplayName("브랜드에 상품을,")
+  @Nested
+  class ProductList {
+
+    @Test
+    @DisplayName("추가하지 않고, 초기 상태인 경우, 상품 리스트의 길이는 0이다.")
+    void thenProductListSizeIsZero_whenInitialProductInBrand() {
+      //given
+      Products products = Products.of();
+      //when
+      int size = products.getProducts().size();
+      //then
+      Assertions.assertThat(size).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("추가하는 경우, 상품 리스트의 길이가 1증가 되어진다.")
+    void thenProductListSizePlus1_whenAddProductInBrand() {
+      //given
+      Products products = Products.of();
+      Product product = new Product(1L,"상품1", BigInteger.valueOf(200),"상품11");
+      //when
+      products.add(product);
+      //then
+      Assertions.assertThat(products.getProducts().size()).isEqualTo(1);
+    }
+  }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductModelTest.java
@@ -1,0 +1,34 @@
+package com.loopers.domain.product;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.loopers.domain.product.embeded.ProductPrice;
+import com.loopers.domain.user.embeded.BirthDay;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigInteger;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ProductModelTest {
+
+  @DisplayName("상품 가격을 책정할때,")
+  @Nested
+  class ProductPriceTest {
+
+    @DisplayName("음수라면, `400 Bad Request`를 반환합니다.")
+    @Test
+    void throw400BadRequestException_whenProductPriceIsUnderZero() {
+      //given
+      BigInteger price = BigInteger.valueOf(-1);
+      // when
+      CoreException result = assertThrows(CoreException.class, () -> ProductPrice.of(price));
+      // then
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+  }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductModelTest.java
@@ -4,11 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.loopers.domain.product.embeded.ProductPrice;
-import com.loopers.domain.user.embeded.BirthDay;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.math.BigInteger;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,9 +22,8 @@ public class ProductModelTest {
     void throw400BadRequestException_whenProductPriceIsUnderZero() {
       //given
       BigInteger price = BigInteger.valueOf(-1);
-      // when
+      // when&then
       CoreException result = assertThrows(CoreException.class, () -> ProductPrice.of(price));
-      // then
       assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }
   }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/stock/StockModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/stock/StockModelTest.java
@@ -1,0 +1,57 @@
+package com.loopers.domain.product.stock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.loopers.domain.product.stock.embeded.ProductStock;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class StockModelTest {
+
+  @DisplayName("재고가 0미만이라면 `400 Bad Request`를 반환합니다.")
+  @Test
+  void throw400BadRequestException_whenStockIsUnderZero() {
+    //given
+    long stock = -1L;
+    // when&then
+    CoreException result = assertThrows(CoreException.class, () -> ProductStock.of(stock));
+    assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+  }
+
+  @DisplayName("재고 감소시 재고가 0미만인 경우 `400 Bad Request`를 반환합니다.")
+  @Test
+  void throw400BadRequestException_whenDecreaseStockIsUnderZero() {
+    //given
+    ProductStock productStock = ProductStock.of(5L);
+    // when&then
+    CoreException result = assertThrows(CoreException.class, () -> productStock.decrease(6L));
+    assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+  }
+
+  @DisplayName("재고 감소시 음수로 재고를 차감하는 경우에는 `400 Bad Request`를 반환합니다.")
+  @Test
+  void throw400BadRequestException_whenDecreaseNegative() {
+    //given
+    ProductStock productStock = ProductStock.of(5L);
+    // when&then
+    CoreException result = assertThrows(CoreException.class, () -> productStock.decrease(-6L));
+    assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+  }
+
+  @DisplayName("재고 정상적으로 감소시킨 경우 재고 객체가 리턴이 되어집니다.")
+  @Test
+  void returnProductStock_whenDecreasePositive() {
+    //given
+    ProductStock productStock = ProductStock.of(10L);
+    ProductStock decreaseStock = ProductStock.of(5L);
+    // when
+    ProductStock resultStock = productStock.decrease(5L);
+    //then
+    assertThat(resultStock).isEqualTo(decreaseStock);
+  }
+
+
+}


### PR DESCRIPTION
## 📌 Summary
브랜드,상품,재고 단위 테스트

## 💬 Review Points
1. 값을 임베디드, Vo 객체로 만들게 되면, 불변 객체로 만들어 되는걸로 알고 있습니다. new 로 만들어도 사용할때마다 new를 사용하면되지만
재 사용성을 줄이는 방법을 고민하다, 정적 메소드 패턴을 이용하는 방법을 선택하였습니다.

## ✅ Checklist
- [ ]  상품 정보 객체는 브랜드 정보, 좋아요 수를 포함한다.
- [ ]  상품의 정렬 조건(`latest`, `price_asc`, `likes_desc`) 을 고려한 조회 기능을 설계했다
- [ ]  상품은 재고를 가지고 있고, 주문 시 차감할 수 있어야 한다
- [X]  재고는 감소만 가능하며 음수 방지는 도메인 레벨에서 처리된다

체크리스트 모두 만족하지는 않네... (하나 만족하네)
상품이 재고를 가지게 만들어두긴함
정렬 조건은 단위라.. 아직 하지 못함..
상품 정보 객체는 브랜드 정보만 들어가있고
좋아요 수를 포함하지는 않음..
