### PR TITLE
동시성 테스트

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -19,7 +19,7 @@ public class LikeFacade {
 
   @Transactional
   public void like(String userId, Long productId) {
-    ProductStatus productStatus = productRepository.has(productId).orElseThrow(
+    ProductStatus productStatus = productRepository.hasWithLock(productId).orElseThrow(
         () -> new CoreException(ErrorType.NOT_FOUND, "해당하는 상품이 존재하지 않습니다.")
     );
     Optional<LikeModel> likeModel = likeRepository.liked(userId, productId);
@@ -36,7 +36,7 @@ public class LikeFacade {
 
   @Transactional
   public void unlike(String userId, Long productId) {
-    ProductStatus productStatus = productRepository.has(productId).orElseThrow(
+    ProductStatus productStatus = productRepository.hasWithLock(productId).orElseThrow(
         () -> new CoreException(ErrorType.NOT_FOUND, "해당하는 상품이 존재하지 않습니다.")
     );
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/stock/StockProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/stock/StockProcessor.java
@@ -2,7 +2,6 @@ package com.loopers.application.payment.stock;
 
 import com.loopers.domain.catalog.product.stock.StockModel;
 import com.loopers.domain.catalog.product.stock.StockRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +12,8 @@ public class StockProcessor {
   private final StockRepository stockRepository;
 
   @Transactional
-  public void decreaseStocks(List<StockDecreaseCommand> orderItems) {
-    for (StockDecreaseCommand orderItem : orderItems) {
-      Long productId = orderItem.productId();
+  public void decreaseStock(Long productId, Long quantity) {
       StockModel stockModel = stockRepository.get(productId);
-      stockModel.decrease(orderItem.quantity());
-    }
+      stockModel.decrease(quantity);
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductModel.java
@@ -4,6 +4,7 @@ import com.loopers.domain.BaseEntity;
 import com.loopers.domain.catalog.product.embeded.ProductName;
 import com.loopers.domain.catalog.product.embeded.ProductPrice;
 import com.loopers.domain.catalog.product.status.ProductStatus;
+import com.loopers.domain.catalog.product.stock.StockModel;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -29,6 +30,9 @@ public class ProductModel extends BaseEntity {
 
   @OneToOne
   private ProductStatus status;
+
+  @OneToOne
+  private StockModel stock;
 
   public ProductModel(Long brandId, String name, BigInteger price, String description) {
     this.brandId = brandId;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductRepository.java
@@ -15,4 +15,6 @@ public interface ProductRepository {
 
   Optional<ProductStatus> has(Long productId);
 
+  Optional<ProductStatus> hasWithLock(Long productId);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/embeded/ProductStock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/embeded/ProductStock.java
@@ -16,7 +16,7 @@ public class ProductStock {
   }
 
   private ProductStock(Long stock) {
-    validate(stock);
+//    validate(stock);
     this.stock = stock;
   }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/embeded/ProductStock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/stock/embeded/ProductStock.java
@@ -16,7 +16,7 @@ public class ProductStock {
   }
 
   private ProductStock(Long stock) {
-//    validate(stock);
+    validate(stock);
     this.stock = stock;
   }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
@@ -7,7 +7,9 @@ import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.math.BigInteger;
+import java.sql.Timestamp;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,6 +25,9 @@ public class PointModel extends BaseEntity {
   private String userId;
   @Embedded
   private Point point;
+
+  @Version
+  private Timestamp version;
 
   public PointModel(String userId) {
     validate(userId);

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -134,6 +135,15 @@ public class ProductRepositoryImpl implements ProductRepository {
     return Optional.ofNullable(query.select(status)
         .from(status)
         .where(status.productId.eq(productId))
+        .fetchOne());
+  }
+
+  @Override
+  public Optional<ProductStatus> hasWithLock(Long productId) {
+    return Optional.ofNullable(query.select(status)
+        .from(status)
+        .where(status.productId.eq(productId))
+        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
         .fetchOne());
   }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/stock/StockJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/stock/StockJpaRepository.java
@@ -1,9 +1,17 @@
 package com.loopers.infrastructure.catalog.product.stock;
 
 import com.loopers.domain.catalog.product.stock.StockModel;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StockJpaRepository extends JpaRepository<StockModel, Long> {
   Optional<StockModel> findByProductId(Long productId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select s FROM StockModel s WHERE s.productId= :productId")
+  Optional<StockModel> findByProductIdWithRock(Long productId);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/stock/StockRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/stock/StockRepositoryImpl.java
@@ -13,7 +13,7 @@ public class StockRepositoryImpl implements StockRepository {
   private final StockJpaRepository stockJpaRepository;
 
   public StockModel get(Long productId) {
-    return stockJpaRepository.findByProductId(productId).orElseThrow(
+    return stockJpaRepository.findByProductIdWithRock(productId).orElseThrow(
         () -> new CoreException(ErrorType.NOT_FOUND, "상품이 존재하지 않습니다.")
     );
   }

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import com.loopers.domain.point.PointModel;
 import com.loopers.domain.point.PointRepository;
 import com.loopers.domain.user.UserModel;
 import com.loopers.domain.user.UserRepository;
+import com.loopers.infrastructure.catalog.product.stock.StockJpaRepository;
 import com.loopers.utils.DatabaseCleanUp;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -45,6 +46,9 @@ class PaymentServiceIntegrationTest {
 
   @Autowired
   private StockRepository stockRepository;
+
+  @Autowired
+  private StockJpaRepository stockJpaRepository;
 
   @Autowired
   private DatabaseCleanUp databaseCleanUp;
@@ -104,14 +108,14 @@ class PaymentServiceIntegrationTest {
   @Test
   void returnDecreasedStockQuantity_whenPaymentCreated() {
     //given
-    StockModel afterStock = stockRepository.get(1L);
+    StockModel afterStock = stockJpaRepository.findByProductId(1L).get();
     pointFacade.charge(userId, BigInteger.valueOf(500000));
     PaymentCommand command = new PaymentCommand(userId, orderCreateInfo.orderNumber(), orderCreateInfo.totalPrice(), "shot");
     //when
     //결제시
     paymentFacade.payment(command);
 
-    StockModel currentStock = stockRepository.get(1L);
+    StockModel currentStock = stockJpaRepository.findByProductId(1L).get();
     //then
     assertThat(currentStock.stock()).isEqualTo(afterStock.stock() - 1L);
   }

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/point/PointUseHandlerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/point/PointUseHandlerTest.java
@@ -1,7 +1,6 @@
 package com.loopers.application.payment.point;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.loopers.domain.point.PointModel;
 import com.loopers.domain.point.PointRepository;

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/point/PointUseHandlerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/point/PointUseHandlerTest.java
@@ -4,7 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.loopers.domain.point.PointModel;
 import com.loopers.domain.point.PointRepository;
+import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.utils.DatabaseCleanUp;
 import java.math.BigInteger;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +28,15 @@ class PointUseHandlerTest {
   @Autowired
   PointRepository pointRepository;
 
-
+  @Autowired
+  PointJpaRepository pointJpaRepository;
+  
+  @Autowired
+  private DatabaseCleanUp databaseCleanUp;
+  @AfterEach
+  void tearDown() {
+    databaseCleanUp.truncateAllTables();
+  }
   @Test
   @DisplayName("포인트가 사용이 되어질때, 포인트가 감소한다.")
   void returnDecreasedPoint_whenPointUsed() {
@@ -34,5 +49,48 @@ class PointUseHandlerTest {
     //then
     PointModel currentPoint = pointRepository.get(userId).get();
     assertThat(currentPoint.getPoint()).isEqualTo(afterPoint.getPoint().subtract(usePoint));
+  }
+
+  @DisplayName("동일한 유저가 여러 기기에서 동시에 주문에도, 포인트가 중복 차감되지 않아야 한다.")
+  @Test
+  void concurrencyTest_pointShouldBeProperlyDontDuplicatedWhenOrdersCreated() throws InterruptedException {
+    // Given
+    pointRepository.save(new PointModel("userId", BigInteger.valueOf(10_000)));
+
+    int threadCount = 100;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch latch = new CountDownLatch(threadCount);
+
+    AtomicInteger successCount = new AtomicInteger();
+    AtomicInteger failCount = new AtomicInteger();
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          pointUseHandler.use("userId", BigInteger.valueOf(1));
+          successCount.incrementAndGet();
+        } catch (Exception e) {
+          failCount.incrementAndGet();
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    latch.await();
+
+    // When
+    PointModel pointModel = pointJpaRepository.findByUserId("userId").orElseThrow();
+
+    // Then
+    BigInteger expected = BigInteger.valueOf(10_000 - successCount.get());
+
+    System.out.println("성공: " + successCount.get());
+    System.out.println("실패: " + failCount.get());
+    System.out.println("최종 포인트: " + pointModel.getPoint());
+    System.out.println("버전 값: " + pointModel.getVersion());
+
+    assertThat(pointModel.getPoint()).isEqualTo(expected);
+    assertThat(successCount.get() + failCount.get()).isEqualTo(threadCount);
   }
 }


### PR DESCRIPTION
## 📌 Summary
동시성 테스트

1. [동시에 주문해도 재고가 정상적으로 차감된다.](https://github.com/Loopers-Team-6/younghun/commit/2390604bc257397085ca06ebeb90a3e76fc36081)
2. [동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.](https://github.com/Loopers-Team-6/younghun/commit/00177ad23d3cd2da75ff13d04508065f5bc327ef)

## 💬 Review Points
동일한 유저가 여러 기기에서 동시에 주문에도, 포인트가 중복 차감되지 않아야 한다. 라고 해서
낙관 락을 선택하기로 결정하였습니다. 왜냐하면 하나의 성공만 허용하고 나머지는 실패한다고 생각하여
낙관 락을 선택하였습니다. 하지만 예상과 달리, 성공이 하나가 아닌 여러개가 성공 하더구요. 제가 고려해야 될것이 있을까요?
코드는 35203875a49772216fb051d930d42927b9772ce9 입니다.


## ✅ Checklist
- [X]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [ ]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- [ ]  동일한 유저가 여러 기기에서 동시에 주문에도, 포인트가 중복 차감되지 않아야 한다.
- [X]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.