### PR TITLE
주문,결제 도메인 수정

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCancelInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCancelInfo.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.orderItem.OrderItemModel;
 import java.math.BigInteger;
 import java.util.List;
 
@@ -9,11 +11,25 @@ public record OrderCancelInfo(
     List<CancelItems> items,
     String orderStaus
 ) {
-}
+  public static OrderCancelInfo from(OrderModel orderModel) {
+    return new OrderCancelInfo(
+        orderModel.getUserId(),
+        orderModel.getOrderNumber(),
+        CancelItems.from(orderModel.getOrderItems())
+        , orderModel.getStatus().name());
+  }
 
-record CancelItems(
-    Long productId,
-    Long quantity,
-    BigInteger price
-) {
+  record CancelItems(
+      Long productId,
+      Long quantity,
+      BigInteger price
+  ) {
+    public static List<CancelItems> from(List<OrderItemModel> orderItems) {
+      return orderItems.stream().map(item ->
+          new CancelItems(
+              item.getProductId(),
+              item.getQuantity(),
+              item.getUnitPrice())).toList();
+    }
+  }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCreateInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCreateInfo.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.orderItem.OrderItemModel;
 import java.math.BigInteger;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -18,6 +20,20 @@ public record OrderCreateInfo(
     ZonedDateTime createdAt,
     ZonedDateTime updatedAt
 ) {
+  public static OrderCreateInfo from(OrderModel orderModel) {
+    return OrderCreateInfo.create()
+        .userId(orderModel.getUserId())
+        .orderId(orderModel.getId())
+        .items(ItemInfos.from(orderModel.getOrderItems()))
+        .orderNumber(orderModel.getOrderNumber())
+        .orderStatus(orderModel.getStatus().name())
+        .address(orderModel.getAddress())
+        .totalPrice(orderModel.getTotalPrice())
+        .memo(orderModel.getMemo())
+        .createdAt(orderModel.getCreatedAt())
+        .updatedAt(orderModel.getUpdatedAt())
+        .build();
+  }
 }
 
 record ItemInfos(
@@ -26,4 +42,14 @@ record ItemInfos(
     BigInteger unitPrice
 ) {
 
+  public static List<ItemInfos> from(List<OrderItemModel> orderItems) {
+    return orderItems
+        .stream().map(
+            orderItem -> new ItemInfos(
+                orderItem.getProductId(),
+                orderItem.getQuantity(),
+                orderItem.getUnitPrice()
+            )
+        ).toList();
+  }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -5,6 +5,7 @@ import com.loopers.application.order.handler.OrderHistoryHandler;
 import com.loopers.application.order.info.OrderCancelInfo;
 import com.loopers.application.order.info.OrderCreateInfo;
 import com.loopers.application.order.processor.OrderProcessor;
+import com.loopers.application.order.processor.OrderStockProcessor;
 import com.loopers.application.order.validator.PointValidator;
 import com.loopers.domain.order.OrderModel;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderFacade {
   private final OrderProcessor orderProcessor;
   private final PointValidator pointValidator;
+  private final OrderStockProcessor stockProcessor;
   private final OrderHistoryHandler orderHistoryHandler;
 
   // 주문 생성
@@ -26,6 +28,9 @@ public class OrderFacade {
 
     //포인트 확인
     pointValidator.check(orderModel.getUserId(), orderModel.getTotalPrice());
+
+    //재고 확인
+    stockProcessor.check(orderModel.getOrderItems());
 
     //히스토리 저장
     orderHistoryHandler.create(orderModel);

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,5 +1,11 @@
 package com.loopers.application.order;
 
+import com.loopers.application.order.command.OrderCreateCommand;
+import com.loopers.application.order.handler.OrderHistoryHandler;
+import com.loopers.application.order.info.OrderCancelInfo;
+import com.loopers.application.order.info.OrderCreateInfo;
+import com.loopers.application.order.processor.OrderProcessor;
+import com.loopers.application.order.validator.PointValidator;
 import com.loopers.domain.order.OrderModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,12 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderFacade {
   private final OrderProcessor orderProcessor;
+  private final PointValidator pointValidator;
   private final OrderHistoryHandler orderHistoryHandler;
+
   // 주문 생성
   @Transactional
   public OrderCreateInfo create(OrderCreateCommand command) {
     //주문서를 만들고
     OrderModel orderModel = orderProcessor.create(command);
+
+    //포인트 확인
+    pointValidator.check(orderModel.getUserId(), orderModel.getTotalPrice());
 
     //히스토리 저장
     orderHistoryHandler.create(orderModel);

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,17 +1,6 @@
 package com.loopers.application.order;
 
-import com.loopers.domain.catalog.product.ProductModel;
-import com.loopers.domain.catalog.product.ProductRepository;
 import com.loopers.domain.order.OrderModel;
-import com.loopers.domain.order.OrderRepository;
-import com.loopers.domain.order.history.OrderHistoryRepository;
-import com.loopers.domain.order.orderItem.OrderItemModel;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,92 +8,30 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class OrderFacade {
-  private final OrderRepository orderRepository;
-  private final OrderHistoryRepository orderHistoryRepository;
-  private final ProductRepository productRepository;
-
+  private final OrderProcessor orderProcessor;
+  private final OrderHistoryHandler orderHistoryHandler;
   // 주문 생성
   @Transactional
   public OrderCreateInfo create(OrderCreateCommand command) {
-    // 계산하기 편하게 map으로 변환
-    Map<Long, Long> items = command.items().stream()
-        .collect(Collectors.toMap(
-            OrderItemCommands::productId,
-            OrderItemCommands::quantity
-        ));
-    // 가져와서 각각의 가격을 가져온다.
-    ArrayList<Long> productIds = new ArrayList<>(items.keySet());
-
-    // 상품 정보를 가져온다.
-    List<ProductModel> products = productRepository.getIn(productIds);
-
-    List<OrderItemModel> orderItemModels = new ArrayList<>();
-
-    // 주문서 저장
-    OrderModel orderModel = orderRepository.save(OrderModel.create()
-        .userId(command.userId())
-        .address(command.address())
-        .memo(command.memo())
-        .build());
-
-    for (ProductModel product : products) {
-      OrderItemModel orderItemModel = items.entrySet().stream().filter(entry ->
-              entry.getKey().equals(product.getId()))
-          .map(entry -> OrderItemModel.builder()
-              .orderId(orderModel.getId())
-              .productId(entry.getKey())
-              .quantity(entry.getValue())
-              .unitPrice(product.getPrice())
-              .build()).findFirst().orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당하는 상품을 찾을 수 없습니다."));
-      orderItemModels.add(orderItemModel);
-    }
-
-    orderModel.addOrderItemsAfterSave(orderItemModels);
+    //주문서를 만들고
+    OrderModel orderModel = orderProcessor.create(command);
 
     //히스토리 저장
-    orderHistoryRepository.save(orderModel);
+    orderHistoryHandler.create(orderModel);
 
-    return OrderCreateInfo.create()
-        .userId(command.userId())
-        .orderId(orderModel.getId())
-        .items(orderModel.getOrderItems()
-            .stream().map(
-                orderItem -> new ItemInfos(
-                    orderItem.getProductId(),
-                    orderItem.getQuantity(),
-                    orderItem.getUnitPrice()
-                )
-            ).toList())
-        .orderNumber(orderModel.getOrderNumber())
-        .orderStatus(orderModel.getStatus().name())
-        .address(orderModel.getAddress())
-        .totalPrice(orderModel.getTotalPrice())
-        .memo(orderModel.getMemo())
-        .createdAt(orderModel.getCreatedAt())
-        .updatedAt(orderModel.getUpdatedAt())
-        .build();
+    //결과 리턴
+    return OrderCreateInfo.from(orderModel);
   }
 
   //주문 취소
   @Transactional
   public OrderCancelInfo cancel(String userId, String orderNumber) {
-    // 주문 확인
-    OrderModel orderModel = orderRepository.ofOrderNumber(userId, orderNumber);
-    // 취소
-    orderModel.cancel();
+    // 주문 취소
+    OrderModel orderModel = orderProcessor.cancel(userId, orderNumber);
     // 히스토리 저장
-    orderHistoryRepository.save(orderModel);
+    orderHistoryHandler.create(orderModel);
     //결과
-    return new OrderCancelInfo(
-        userId,
-        orderNumber,
-        orderModel.getOrderItems().stream().map(item ->
-            new CancelItems(
-                item.getProductId(),
-                item.getQuantity(),
-                item.getUnitPrice())).toList()
-        , orderModel.getStatus().name()
-    );
+    return OrderCancelInfo.from(orderModel);
   }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderHistoryHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderHistoryHandler.java
@@ -1,0 +1,19 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.history.OrderHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OrderHistoryHandler {
+  private final OrderHistoryRepository orderHistoryRepository;
+
+
+  @Transactional
+  public void create(OrderModel orderModel) {
+    orderHistoryRepository.save(orderModel);
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderProcessor.java
@@ -1,0 +1,68 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.catalog.product.ProductModel;
+import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.order.orderItem.OrderItemModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OrderProcessor {
+  private final ProductRepository productRepository;
+  private final OrderRepository orderRepository;
+
+  @Transactional
+  public OrderModel create(OrderCreateCommand command) {
+    // 계산하기 편하게 map으로 변환
+    Map<Long, Long> items = command.items().stream()
+        .collect(Collectors.toMap(
+            OrderItemCommands::productId,
+            OrderItemCommands::quantity
+        ));
+
+    // 가져와서 각각의 가격을 가져온다.
+    ArrayList<Long> productIds = new ArrayList<>(items.keySet());
+
+    // 상품 정보를 가져온다.
+    List<ProductModel> products = productRepository.getIn(productIds);
+
+    List<OrderItemModel> orderItemModels = new ArrayList<>();
+    // 주문서 저장
+    OrderModel orderModel = orderRepository.save(OrderModel.create()
+        .userId(command.userId())
+        .address(command.address())
+        .memo(command.memo())
+        .build());
+
+    for (ProductModel product : products) {
+      OrderItemModel orderItemModel = items.entrySet().stream().filter(entry ->
+              entry.getKey().equals(product.getId()))
+          .map(entry -> OrderItemModel.builder()
+              .orderId(orderModel.getId())
+              .productId(entry.getKey())
+              .quantity(entry.getValue())
+              .unitPrice(product.getPrice())
+              .build()).findFirst().orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당하는 상품을 찾을 수 없습니다."));
+      orderItemModels.add(orderItemModel);
+    }
+
+    orderModel.addOrderItemsAfterSave(orderItemModels);
+    return orderModel;
+  }
+
+  public OrderModel cancel(String userId, String orderNumber) {
+    OrderModel orderModel = orderRepository.ofOrderNumber(userId, orderNumber);
+    orderModel.cancel();
+    return orderModel;
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/command/OrderCreateCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/command/OrderCreateCommand.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.command;
 
 import java.util.List;
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/command/OrderItemCommands.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/command/OrderItemCommands.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.command;
 
 public record OrderItemCommands(
     Long productId,

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/handler/OrderHistoryHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/handler/OrderHistoryHandler.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.handler;
 
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.history.OrderHistoryRepository;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/info/ItemInfos.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/info/ItemInfos.java
@@ -1,0 +1,23 @@
+package com.loopers.application.order.info;
+
+import com.loopers.domain.order.orderItem.OrderItemModel;
+import java.math.BigInteger;
+import java.util.List;
+
+public record ItemInfos(
+    Long productId,
+    Long quantity,
+    BigInteger unitPrice
+) {
+
+  public static List<ItemInfos> from(List<OrderItemModel> orderItems) {
+    return orderItems
+        .stream().map(
+            orderItem -> new ItemInfos(
+                orderItem.getProductId(),
+                orderItem.getQuantity(),
+                orderItem.getUnitPrice()
+            )
+        ).toList();
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/info/OrderCancelInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/info/OrderCancelInfo.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.info;
 
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.orderItem.OrderItemModel;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/info/OrderCreateInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/info/OrderCreateInfo.java
@@ -1,7 +1,6 @@
 package com.loopers.application.order.info;
 
 import com.loopers.domain.order.OrderModel;
-import com.loopers.domain.order.orderItem.OrderItemModel;
 import java.math.BigInteger;
 import java.time.ZonedDateTime;
 import java.util.List;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/info/OrderCreateInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/info/OrderCreateInfo.java
@@ -1,4 +1,4 @@
-package com.loopers.application.order;
+package com.loopers.application.order.info;
 
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.orderItem.OrderItemModel;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/info/OrderCreateInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/info/OrderCreateInfo.java
@@ -35,21 +35,3 @@ public record OrderCreateInfo(
         .build();
   }
 }
-
-record ItemInfos(
-    Long productId,
-    Long quantity,
-    BigInteger unitPrice
-) {
-
-  public static List<ItemInfos> from(List<OrderItemModel> orderItems) {
-    return orderItems
-        .stream().map(
-            orderItem -> new ItemInfos(
-                orderItem.getProductId(),
-                orderItem.getQuantity(),
-                orderItem.getUnitPrice()
-            )
-        ).toList();
-  }
-}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/processor/OrderProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/processor/OrderProcessor.java
@@ -1,5 +1,7 @@
-package com.loopers.application.order;
+package com.loopers.application.order.processor;
 
+import com.loopers.application.order.command.OrderCreateCommand;
+import com.loopers.application.order.command.OrderItemCommands;
 import com.loopers.domain.catalog.product.ProductModel;
 import com.loopers.domain.catalog.product.ProductRepository;
 import com.loopers.domain.order.OrderModel;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/processor/OrderStockProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/processor/OrderStockProcessor.java
@@ -1,0 +1,29 @@
+package com.loopers.application.order.processor;
+
+import com.loopers.domain.catalog.product.stock.StockModel;
+import com.loopers.domain.catalog.product.stock.StockRepository;
+import com.loopers.domain.order.orderItem.OrderItemModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderStockProcessor {
+  private final StockRepository stockRepository;
+
+  public void check(List<OrderItemModel> orderItems) {
+    for (OrderItemModel orderItem : orderItems) {
+      StockModel stockModel = stockRepository.get(orderItem.getProductId());
+      Long hasStock = stockModel.stock();
+      // 주문 수량
+      Long orderItemQuantity = orderItem.getQuantity();
+
+      if (hasStock < orderItemQuantity) {
+        throw new CoreException(ErrorType.BAD_REQUEST, "주문 수량이 재고보다 많습니다.");
+      }
+    }
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/validator/PointValidator.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/validator/PointValidator.java
@@ -1,0 +1,28 @@
+package com.loopers.application.order.validator;
+
+import com.loopers.domain.point.PointModel;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigInteger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PointValidator {
+  private final PointRepository pointRepository;
+
+  public void check(String userId, BigInteger orderPrice) {
+    PointModel pointModel = pointRepository.get(userId).orElseThrow(() ->
+        new CoreException(ErrorType.NOT_FOUND, "포인트가 존재하지 않습니다.")
+    );
+
+    BigInteger hasPoint = pointModel.getPoint();
+
+    if (hasPoint.compareTo(orderPrice) < 0) {
+      throw new CoreException(ErrorType.BAD_REQUEST, "포인트가 부족합니다.");
+    }
+
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -1,8 +1,9 @@
 package com.loopers.application.payment;
 
 
-import com.loopers.application.payment.point.PointUseHandler;
-import com.loopers.application.payment.stock.StockProcessor;
+import com.loopers.application.payment.command.PaymentCommand;
+import com.loopers.application.payment.handler.PointUseHandler;
+import com.loopers.application.payment.processor.StockProcessor;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.OrderRepository;
 import com.loopers.domain.order.orderItem.OrderItemModel;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/command/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/command/PaymentCommand.java
@@ -1,4 +1,4 @@
-package com.loopers.application.payment;
+package com.loopers.application.payment.command;
 
 import java.math.BigInteger;
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/command/StockDecreaseCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/command/StockDecreaseCommand.java
@@ -1,4 +1,4 @@
-package com.loopers.application.payment.stock;
+package com.loopers.application.payment.command;
 
 public record StockDecreaseCommand(Long productId, Long quantity) {
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/handler/PointUseHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/handler/PointUseHandler.java
@@ -1,4 +1,4 @@
-package com.loopers.application.payment.point;
+package com.loopers.application.payment.handler;
 
 import com.loopers.domain.point.PointModel;
 import com.loopers.domain.point.PointRepository;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/StockProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/StockProcessor.java
@@ -1,4 +1,4 @@
-package com.loopers.application.payment.stock;
+package com.loopers.application.payment.processor;
 
 import com.loopers.domain.catalog.product.stock.StockModel;
 import com.loopers.domain.catalog.product.stock.StockRepository;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,5 +1,9 @@
 package com.loopers.domain.payment;
 
+import java.util.Optional;
+
 public interface PaymentRepository {
   PaymentModel save(PaymentModel paymentModel);
+
+  Optional<PaymentModel> get(String orderNumber);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Version;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -20,6 +21,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Setter
+@EqualsAndHashCode(callSuper = true)
 public class PointModel extends BaseEntity {
 
   private String userId;

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -1,8 +1,10 @@
 package com.loopers.infrastructure.payment;
 
 import com.loopers.domain.payment.PaymentModel;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentJpaRepository extends JpaRepository<PaymentModel, Long> {
 
+  Optional<PaymentModel> findByOrderNumber(String orderNumber);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.payment;
 
 import com.loopers.domain.payment.PaymentModel;
 import com.loopers.domain.payment.PaymentRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +14,10 @@ public class PaymentRepositoryImpl implements PaymentRepository {
   @Override
   public PaymentModel save(PaymentModel paymentModel) {
     return repository.save(paymentModel);
+  }
+
+  @Override
+  public Optional<PaymentModel> get(String orderNumber) {
+    return repository.findByOrderNumber(orderNumber);
   }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderServiceIntegrationTest.java
@@ -4,15 +4,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.loopers.application.order.command.OrderCreateCommand;
+import com.loopers.application.order.command.OrderItemCommands;
+import com.loopers.application.order.info.OrderCancelInfo;
+import com.loopers.application.order.info.OrderCreateInfo;
 import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.point.PointModel;
+import com.loopers.domain.point.PointRepository;
 import com.loopers.infrastructure.order.OrderJpaRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,6 +35,8 @@ class OrderServiceIntegrationTest {
   @Autowired
   private OrderJpaRepository repository;
 
+  @Autowired
+  private PointRepository pointRepository;
   @Autowired
   private DatabaseCleanUp databaseCleanUp;
 
@@ -124,5 +134,33 @@ class OrderServiceIntegrationTest {
     assertThat(cancel.orderStaus()).isEqualTo("CANCEL");
   }
 
+  @DisplayName("주문시 포인트 확인,")
+  @Nested
+  class Point {
+
+    @DisplayName("주문 시 유저의 포인트 잔액이 부족할 경우 `400 Bad Request`를 반환한다.")
+    @Test
+    void throw400_whenUserHasLessPointsThanOrderRequires() {
+      //given
+      List<OrderItemCommands> orderItemModels = new ArrayList<>();
+
+      orderItemModels.add(new OrderItemCommands(
+          1L, 1L
+      ));
+
+      OrderCreateCommand command =
+          new OrderCreateCommand("userId",
+              "서울시 송파구"
+              , orderItemModels, "메모..");
+
+      pointRepository.save(new PointModel("userId", BigInteger.valueOf(1)));
+
+      //when
+      CoreException result = assertThrows(CoreException.class, () -> orderFacade.create(command));
+      //then
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+    }
+  }
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderServiceIntegrationTest.java
@@ -163,4 +163,34 @@ class OrderServiceIntegrationTest {
     }
   }
 
+  @DisplayName("주문시, 재고 확인")
+  @Nested
+  class Stock {
+
+    @DisplayName("주문 시 재고가 부족할 경우 `400 Bad Request`를 반환한다.")
+    @Test
+    void throw400_whenCreatingOrderWithInsufficientStock() {
+      //given
+      List<OrderItemCommands> orderItemModels = new ArrayList<>();
+
+      orderItemModels.add(new OrderItemCommands(
+          1L, 3000L
+      ));
+
+      OrderCreateCommand command =
+          new OrderCreateCommand("userId",
+              "서울시 송파구"
+              , orderItemModels, "메모..");
+
+      pointRepository.save(new PointModel("userId", BigInteger.valueOf(500000000)));
+
+      //when
+      CoreException result = assertThrows(CoreException.class, () -> orderFacade.create(command));
+      //then
+      assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+    }
+
+  }
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderServiceIntegrationTest.java
@@ -64,6 +64,7 @@ class OrderServiceIntegrationTest {
             "서울시 송파구"
             , orderItemModels, "메모..");
     //when
+    pointRepository.save(new PointModel("userId", BigInteger.valueOf(500000000)));
     OrderCreateInfo orderCreateInfo = orderFacade.create(command);
 
     OrderModel dbModel = repository.findById(orderCreateInfo.orderId()).get();
@@ -100,6 +101,7 @@ class OrderServiceIntegrationTest {
         new OrderCreateCommand(order,
             "서울시 송파구"
             , orderItemModels, "메모..");
+    pointRepository.save(new PointModel("userId", BigInteger.valueOf(500000000)));
     OrderCreateInfo orderCreateInfo = orderFacade.create(command);
     //when
     CoreException result = assertThrows(CoreException.class, () -> orderFacade.cancel("userId2", orderCreateInfo.orderNumber()));
@@ -127,6 +129,7 @@ class OrderServiceIntegrationTest {
         new OrderCreateCommand(order,
             "서울시 송파구"
             , orderItemModels, "메모..");
+    pointRepository.save(new PointModel("userId", BigInteger.valueOf(500000000)));
     OrderCreateInfo orderCreateInfo = orderFacade.create(command);
     //when
     OrderCancelInfo cancel = orderFacade.cancel(order, orderCreateInfo.orderNumber());

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/OrderStockProcessorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/OrderStockProcessorTest.java
@@ -2,7 +2,7 @@ package com.loopers.application.payment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.loopers.application.payment.stock.StockProcessor;
+import com.loopers.application.payment.processor.StockProcessor;
 import com.loopers.domain.catalog.product.stock.StockModel;
 import com.loopers.domain.catalog.product.stock.StockRepository;
 import com.loopers.infrastructure.catalog.product.ProductJpaRepository;

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/OrderStockProcessorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/OrderStockProcessorTest.java
@@ -20,7 +20,7 @@ import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest
 @Sql("/sql/test-fixture.sql")
-public class StockProcessorTest {
+public class OrderStockProcessorTest {
   @Autowired
   private ProductJpaRepository productJpaRepository;
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
@@ -2,10 +2,10 @@ package com.loopers.application.payment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.loopers.application.order.OrderCreateCommand;
-import com.loopers.application.order.OrderCreateInfo;
+import com.loopers.application.order.command.OrderCreateCommand;
+import com.loopers.application.order.info.OrderCreateInfo;
 import com.loopers.application.order.OrderFacade;
-import com.loopers.application.order.OrderItemCommands;
+import com.loopers.application.order.command.OrderItemCommands;
 import com.loopers.application.point.PointFacade;
 import com.loopers.domain.catalog.product.stock.StockModel;
 import com.loopers.domain.catalog.product.stock.StockRepository;

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
@@ -39,7 +39,7 @@ class PaymentServiceIntegrationTest {
   @Autowired
   private PointRepository pointRepository;
   @Autowired
-  private PointFacade  pointFacade;
+  private PointFacade pointFacade;
 
   @Autowired
   private UserRepository userRepository;
@@ -68,6 +68,9 @@ class PaymentServiceIntegrationTest {
         new OrderCreateCommand(userId,
             "서울시 송파구"
             , orderItemModels, "메모..");
+
+    pointRepository.save(new PointModel(userId, BigInteger.valueOf(50000000)));
+
     orderCreateInfo = orderFacade.create(command);
 
     UserModel userModel = userRepository.save(
@@ -90,11 +93,9 @@ class PaymentServiceIntegrationTest {
   void returnDecreasePoint_whenPaymentCreated() {
     //given
     String orderNumber = orderCreateInfo.orderNumber();
-    pointFacade.charge(userId, BigInteger.valueOf(500000));
     PointModel afterPoint = pointRepository.get(userId).get();
     BigInteger totalPrice = BigInteger.valueOf(100000);
     PaymentCommand command = new PaymentCommand(userId, orderNumber, totalPrice, "shot");
-
     //when
     PaymentInfo payment = paymentFacade.payment(command);
     PointModel currentPoint = pointRepository.get(userId).get();
@@ -119,5 +120,5 @@ class PaymentServiceIntegrationTest {
     //then
     assertThat(currentStock.stock()).isEqualTo(afterStock.stock() - 1L);
   }
-      
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
@@ -1,26 +1,38 @@
 package com.loopers.application.payment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.loopers.application.order.command.OrderCreateCommand;
+import com.loopers.application.order.info.ItemInfos;
 import com.loopers.application.order.info.OrderCreateInfo;
 import com.loopers.application.order.OrderFacade;
 import com.loopers.application.order.command.OrderItemCommands;
+import com.loopers.application.payment.command.PaymentCommand;
 import com.loopers.application.point.PointFacade;
 import com.loopers.domain.catalog.product.stock.StockModel;
 import com.loopers.domain.catalog.product.stock.StockRepository;
+import com.loopers.domain.payment.PaymentModel;
+import com.loopers.domain.payment.PaymentRepository;
 import com.loopers.domain.point.PointModel;
 import com.loopers.domain.point.PointRepository;
 import com.loopers.domain.user.UserModel;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.infrastructure.catalog.product.stock.StockJpaRepository;
+import com.loopers.infrastructure.point.PointJpaRepository;
 import com.loopers.utils.DatabaseCleanUp;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,10 +46,16 @@ class PaymentServiceIntegrationTest {
   private PaymentFacade paymentFacade;
 
   @Autowired
+  private PaymentRepository paymentRepository;
+
+  @Autowired
   private OrderFacade orderFacade;
 
   @Autowired
   private PointRepository pointRepository;
+  @Autowired
+  private PointJpaRepository pointJpaRepository;
+
   @Autowired
   private PointFacade pointFacade;
 
@@ -61,7 +79,7 @@ class PaymentServiceIntegrationTest {
     List<OrderItemCommands> orderItemModels = new ArrayList<>();
 
     orderItemModels.add(new OrderItemCommands(
-        1L, 1L
+        1L, 10L
     ));
     userId = "userId";
     OrderCreateCommand command =
@@ -119,6 +137,93 @@ class PaymentServiceIntegrationTest {
     StockModel currentStock = stockJpaRepository.findByProductId(1L).get();
     //then
     assertThat(currentStock.stock()).isEqualTo(afterStock.stock() - 1L);
+  }
+
+  @DisplayName("결제 롤백 테스트,")
+  @Nested
+  class Rollback {
+    @DisplayName("포인트가 부족한 경우, 결제가 생성되지 않는다. (재고가 감소하지 않는다.)")
+    @Test
+    void shouldRollbackPayment_whenPointIsInsufficient() {
+      //given
+      String orderNumber = orderCreateInfo.orderNumber();
+      List<Long> orderProducts = orderCreateInfo.items()
+          .stream().map(ItemInfos::productId).toList();
+      Map<Long, Long> originProductStock = stockJpaRepository.findAll()
+          .stream().filter(
+              stock -> orderProducts.contains(stock.getProductId())
+          )
+          .collect(Collectors.toMap(
+              StockModel::getProductId,
+              StockModel::stock
+          ));
+
+      // 포인트 1로 변환
+      pointJpaRepository.deleteAll();
+      PointModel model = pointRepository.save(new PointModel(userId, BigInteger.valueOf(1)));
+
+      PaymentCommand payment = new PaymentCommand(
+          userId,
+          orderNumber,
+          BigInteger.valueOf(30000),
+          "설명"
+      );
+
+      //when
+      assertThatThrownBy(() -> paymentFacade.payment(payment));
+      Optional<PaymentModel> paymentModel = paymentRepository.get(orderNumber);
+
+      Map<Long, Long> currentProductStock = stockJpaRepository.findAll()
+          .stream().filter(
+              stock -> orderProducts.contains(stock.getProductId())
+          )
+          .collect(Collectors.toMap(
+              StockModel::getProductId,
+              StockModel::stock
+          ));
+
+      //then
+
+      //주문 상품은 생성되지 않아야 한다.
+      assertThat(paymentModel).isEmpty();
+
+      // 재고 확인 재고는 변경되지 않는다.
+      for (Entry<Long, Long> entry : originProductStock.entrySet()) {
+        assertThat(currentProductStock.get(entry.getKey())).isEqualTo(entry.getValue());
+      }
+    }
+
+
+    @DisplayName("재고가 부족한 경우, 결제가 생성되지 않는다. (포인트는 감소하지 않는다.)")
+    @Test
+    void shouldRollbackPayment_whenStocksIsInsufficient() {
+      //given
+      String orderNumber = orderCreateInfo.orderNumber();
+      // 기존 포인트
+      PointModel hasPoint = pointRepository.get(userId).get();
+      // 모든 재고는 재거한다.
+      stockJpaRepository.deleteAll();
+      stockJpaRepository.save(new StockModel(1L, 1L));
+
+      PaymentCommand payment = new PaymentCommand(
+          userId,
+          orderNumber,
+          BigInteger.valueOf(30000),
+          "설명"
+      );
+
+      //when
+      assertThatThrownBy(() -> paymentFacade.payment(payment));
+      PointModel currentPoint = pointRepository.get(userId).get();
+      Optional<PaymentModel> paymentModel = paymentRepository.get(orderNumber);
+
+      //then
+      //주문 상품은 생성되지 않아야 한다.
+      assertThat(paymentModel).isEmpty();
+      //포인트는 감소하지 않는다.
+      assertThat(hasPoint.getPoint()).isEqualTo(currentPoint.getPoint());
+
+    }
   }
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentServiceIntegrationTest.java
@@ -2,13 +2,12 @@ package com.loopers.application.payment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.loopers.application.order.OrderFacade;
 import com.loopers.application.order.command.OrderCreateCommand;
+import com.loopers.application.order.command.OrderItemCommands;
 import com.loopers.application.order.info.ItemInfos;
 import com.loopers.application.order.info.OrderCreateInfo;
-import com.loopers.application.order.OrderFacade;
-import com.loopers.application.order.command.OrderItemCommands;
 import com.loopers.application.payment.command.PaymentCommand;
 import com.loopers.application.point.PointFacade;
 import com.loopers.domain.catalog.product.stock.StockModel;
@@ -136,7 +135,7 @@ class PaymentServiceIntegrationTest {
 
     StockModel currentStock = stockJpaRepository.findByProductId(1L).get();
     //then
-    assertThat(currentStock.stock()).isEqualTo(afterStock.stock() - 1L);
+    assertThat(currentStock.stock()).isEqualTo(afterStock.stock() - 10L);
   }
 
   @DisplayName("결제 롤백 테스트,")

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/point/PointUseHandlerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/point/PointUseHandlerTest.java
@@ -2,6 +2,7 @@ package com.loopers.application.payment.point;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.loopers.application.payment.handler.PointUseHandler;
 import com.loopers.domain.point.PointModel;
 import com.loopers.domain.point.PointRepository;
 import com.loopers.infrastructure.point.PointJpaRepository;


### PR DESCRIPTION
## 📌 Summary
주문,결제 도메인 수정

## 💬 Review Points

포인트와 재고 같은 경우, 주문 쪽에서 파악을 해야 하는지에 대해 고민이 있었습니다.
왜냐하면 실질적으로 결제시에 포인트와 재고의 차감이 발생한고 생각합니다. 
그래서 기존에는 결제에서만 벨리데이션을 처리하였습니다. 곰곰히 생각해보니 주문쪽에서 하지 않을 이유는 없더라구요
결국 주문쪽에도 재고와 포인트를 벨리데이션 처리를 하였습니다.

그러다 고민이 생겼는데요. 만약에 PG사가 도입이 되어진다면, 포인트의 역할이 달라질거라고 생각합니다. 기존에는 포인트로 결제하는 느낌이 강했지만 PG사 도입 이후에는 포인트는 직접적인 결제가 아니라 결제를 도와주는 수단으로 바뀐다는 생각이 들었습니다. 
그렇다는건 주문이랑 결제쪽의 포인트 벨리데이션은 변경이 될수 있다고 생각합니다. 더 나아가면 없어질수도 있지 않을까 생각합니다.
포인트 벨리데이션와 대해 멘토님은 어떻게 생각하시나요?

## ✅ Checklist
- [X]  주문 전체 흐름에 대해 원자성이 보장되어야 한다. (3주차때 완료)
- [ ]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [X]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
[feat: 재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.](https://github.com/Loopers-Team-6/younghun/commit/c3b525e1fad47fdabe69ad8614df868261c52f72)
- [X]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
[feat: 주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다.](https://github.com/Loopers-Team-6/younghun/commit/a9d5eef3de262e6e5705566e5e860ded7fe44e1a)
- [ ]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다. (재고,포인트 확인)
[쿠폰, 재고 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.](https://github.com/Loopers-Team-6/younghun/commit/bbb06cc2e08e6498f1af2475d5cd8b8814417028)
- [X]  주문 성공 시, 모든 처리는 정상 반영되어야 한다.  (3주차때 완료) // 결재 처리시
--> deleteAll()이 되어 있는 부분 변경해야 함