### PR TITLE
[Round5] 인덱스, 캐시

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Root
 │   └── 📦 commerce-api
 ├── modules ( reusable-configurations )
 │   └── 📦 jpa
+│   └── 📦 redis
 └── supports ( add-ons )
     ├── 📦 monitoring
     └── 📦 logging

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
@@ -17,4 +18,5 @@ dependencies {
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
 }

--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -5,7 +5,9 @@ import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class CommerceApiApplication {

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductCommand.java
@@ -38,6 +38,3 @@ public record ProductCommand(
 
 }
 
-enum SortOption {
-  LATEST, PRICE_ASC, LIKES_DESC
-}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductContents.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductContents.java
@@ -1,0 +1,23 @@
+package com.loopers.application.catalog.product;
+
+import java.math.BigInteger;
+import java.time.ZonedDateTime;
+
+public record ProductContents(
+    String name,
+    Long id,
+    String brandName,
+    int likeCount,
+    BigInteger price,
+    ZonedDateTime createdAt,
+    ZonedDateTime updatedAt
+) {
+
+  public static ProductContents of(String name, Long id,
+                                   String brandName,
+                                   int likeCount,
+                                   BigInteger price, ZonedDateTime createdAt,
+                                   ZonedDateTime updatedAt) {
+    return new ProductContents(name, id, brandName, likeCount, price, createdAt, updatedAt);
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductContents.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductContents.java
@@ -8,16 +8,13 @@ public record ProductContents(
     Long id,
     String brandName,
     int likeCount,
-    BigInteger price,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
+    BigInteger price
 ) {
 
   public static ProductContents of(String name, Long id,
                                    String brandName,
                                    int likeCount,
-                                   BigInteger price, ZonedDateTime createdAt,
-                                   ZonedDateTime updatedAt) {
-    return new ProductContents(name, id, brandName, likeCount, price, createdAt, updatedAt);
+                                   BigInteger price) {
+    return new ProductContents(name, id, brandName, likeCount, price);
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
@@ -30,6 +30,10 @@ public class ProductFacade {
                     p.getName(), p.getId(), p.getBrandName(), p.getLikedCount(), p.getPrice(), p.getCreatedAt(), p.getUpdateAt()
                 ))
                 .collect(Collectors.toList()))
+            .page(search.getNumber())
+            .size(search.getSize())
+            .totalPages(search.getTotalPages())
+            .totalElements(search.getTotalElements())
             .build();
   }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
@@ -1,22 +1,13 @@
 package com.loopers.application.catalog.product;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.catalog.product.warmup.ProductWarmupProcessor;
 import com.loopers.domain.catalog.product.ProductProjection;
 import com.loopers.domain.catalog.product.ProductRepository;
-import com.loopers.domain.catalog.product.cache.ProductCacheRepository;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -24,7 +15,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProductFacade {
   private final ProductRepository productRepository;
-  private final ProductCacheRepository cacheRepository;
+  private final ProductWarmupProcessor warmupProcessor;
 
   /*
   latest, price_asc, likes_desc
@@ -32,7 +23,7 @@ public class ProductFacade {
 
   // 목록 조회
   public ProductSearchInfo search(ProductCommand command) {
-    Page<ProductProjection> searchData = getSearchData(command);
+    Page<ProductProjection> searchData = warmupProcessor.searchData(command);
     List<ProductProjection> products = searchData.getContent();
     return
         ProductSearchInfo.builder()
@@ -47,30 +38,6 @@ public class ProductFacade {
             .build();
   }
 
-  public Page<ProductProjection> getSearchData(ProductCommand command) {
-    String key = "product:rank:10";
-    PageRequest page = PageRequest.of(command.currentPage(), command.perSize());
-    // 1. 캐시 사용 조건(좋아요순 정렬)이면서 캐시에 값이 실제로 존재할 때만 캐시 로직 실행
-    if (command.sort() == SortOption.LIKES_DESC) {
-      String value = cacheRepository.get(key);
-      if (value != null) {
-        log.info("cache hit");
-        try {
-          List<ProductProjection> cacheContent = new ObjectMapper().readValue(value, new TypeReference<>() {
-          });
-          // 캐시 처리 성공 시, 여기서 결과를 바로 반환하고 메서드를 종료합니다.
-          return new PageImpl<>(cacheContent, Pageable.ofSize(10), 10);
-        } catch (JsonProcessingException e) {
-          throw new CoreException(ErrorType.INTERNAL_ERROR, "json parse error : " + e.getMessage());
-        }
-      }
-      // '좋아요순'이지만 캐시에 값이 없는 경우 (cache miss)
-      log.info("cache miss");
-    }
-    // 2. 위 if 블록의 조건을 만족하지 못한 모든 경우 (캐시를 사용하지 않는 정렬 or 캐시 미스)
-    // 이 코드가 실행된다는 것은 DB 조회가 필요하다는 의미입니다.
-    return productRepository.search(command.toCriteria(), page);
-  }
 
   // 상세 조회
   public ProductGetInfo get(Long id) {
@@ -87,30 +54,6 @@ public class ProductFacade {
   }
 
   public void rank() {
-    String key = "product:rank:10";
-    ObjectMapper objectMapper = new ObjectMapper();
-    String productRankValue = cacheRepository.get(key);
-    if (productRankValue != null) {
-      log.info("TTL 강제 초기화");
-      cacheRepository.remove(key);
-    }
-
-    ProductCommand command = ProductCommand.builder()
-        .perSize(10)
-        .currentPage(0)
-        .sort(SortOption.LIKES_DESC)
-        .build();
-
-    Page<ProductProjection> search = productRepository.search(command.toCriteria(), PageRequest.of(0, 10));
-    String value;
-    try {
-      value = objectMapper.writeValueAsString(search.getContent());
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-
-    log.info("warm up data : {}", value);
-    cacheRepository.put(key, value, Duration.ofMinutes(10));
-
+    warmupProcessor.warmup();
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
@@ -1,19 +1,26 @@
 package com.loopers.application.catalog.product;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.domain.catalog.product.ProductProjection;
 import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.domain.catalog.product.cache.ProductCacheRepository;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ProductFacade {
   private final ProductRepository productRepository;
-
+  private final ProductCacheRepository cacheRepository;
 
   /*
   latest, price_asc, likes_desc
@@ -21,13 +28,26 @@ public class ProductFacade {
 
   // 목록 조회
   public ProductSearchInfo search(ProductCommand command) {
+    String key = "product:rank:10";
     PageRequest page = PageRequest.of(command.currentPage(), command.perSize());
-    Page<ProductProjection> search = productRepository.search(command.toCriteria(), page);
+    String value = cacheRepository.get(key);
+    Page<ProductProjection> search;
+    if (value == null) {
+      search = productRepository.search(command.toCriteria(), page);
+    } else {
+      try {
+        List<ProductProjection> cacheContent = new ObjectMapper().readValue(value, new TypeReference<>() {
+        });
+        search = new PageImpl<>(cacheContent, Pageable.ofSize(10), 1000000);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
     List<ProductProjection> products = search.getContent();
     return
         ProductSearchInfo.builder()
             .contents(products.stream().map(p -> ProductContents.of(
-                    p.getName(), p.getId(), p.getBrandName(), p.getLikedCount(), p.getPrice(), p.getCreatedAt(), p.getUpdateAt()
+                    p.getName(), p.getId(), p.getBrandName(), p.getLikedCount(), p.getPrice()
                 ))
                 .collect(Collectors.toList()))
             .page(search.getNumber())
@@ -48,9 +68,31 @@ public class ProductFacade {
         .price(productProjection.getPrice())
         .description(productProjection.getDescription())
         .likedCount(productProjection.getLikedCount())
-        .createdAt(productProjection.getCreatedAt())
-        .updatedAt(productProjection.getUpdateAt())
         .build();
   }
 
+  public void rank() {
+    String key = "product:rank:10";
+    ObjectMapper objectMapper = new ObjectMapper();
+    String productRankValue = cacheRepository.get(key);
+    if (productRankValue != null) {
+      return;
+    }
+
+    ProductCommand command = ProductCommand.builder()
+        .perSize(10)
+        .currentPage(0)
+        .sort(SortOption.LIKES_DESC)
+        .build();
+
+    Page<ProductProjection> search = productRepository.search(command.toCriteria(), PageRequest.of(0, 10));
+    String value = null;
+    try {
+      value = objectMapper.writeValueAsString(search.getContent());
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+    cacheRepository.put(key, value, Duration.ofMinutes(10));
+
+  }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductFacade.java
@@ -27,7 +27,7 @@ public class ProductFacade {
     return
         ProductSearchInfo.builder()
             .contents(products.stream().map(p -> ProductContents.of(
-                    p.getName(), p.getBrandId(), p.getBrandName(), p.getLikedCount(), p.getPrice(), p.getCreatedAt(), p.getUpdateAt()
+                    p.getName(), p.getId(), p.getBrandName(), p.getLikedCount(), p.getPrice(), p.getCreatedAt(), p.getUpdateAt()
                 ))
                 .collect(Collectors.toList()))
             .build();

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductSearchInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductSearchInfo.java
@@ -7,7 +7,7 @@ public record ProductSearchInfo(
     List<ProductContents> contents,
     int page,
     int size,
-    int totalElements,
+    long totalElements,
     int totalPages
 ) {
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductSearchInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/ProductSearchInfo.java
@@ -1,7 +1,5 @@
 package com.loopers.application.catalog.product;
 
-import java.math.BigInteger;
-import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -18,21 +16,3 @@ public record ProductSearchInfo(
   }
 }
 
-record ProductContents(
-    String name,
-    Long brandId,
-    String brandName,
-    int likeCount,
-    BigInteger price,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) {
-
-  public static ProductContents of(String name, Long brandId,
-                                   String brandName,
-                                   int likeCount,
-                                   BigInteger price, ZonedDateTime createdAt,
-                                   ZonedDateTime updatedAt) {
-    return new ProductContents(name, brandId, brandName, likeCount, price, createdAt, updatedAt);
-  }
-}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/SortOption.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/SortOption.java
@@ -1,0 +1,5 @@
+package com.loopers.application.catalog.product;
+
+public enum SortOption {
+  LATEST, PRICE_ASC, LIKES_DESC
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductLikeWarmUp.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductLikeWarmUp.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class ProductLikeWarmUp {
   private final ProductWarmupProcessor warmupProcessor;
 
-  @Scheduled(cron = "* */5 * * * *")
+  @Scheduled(cron = "0 0 1 * * *")
   public void runTaskWithCron() {
     log.info("Cron 스케쥴 작업 실행: {}", LocalDateTime.now());
     warmupProcessor.warmup();

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductLikeWarmUp.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductLikeWarmUp.java
@@ -1,0 +1,58 @@
+package com.loopers.application.catalog.product.warmup;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.catalog.product.ProductCommand;
+import com.loopers.application.catalog.product.SortOption;
+import com.loopers.domain.catalog.product.ProductProjection;
+import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.domain.catalog.product.cache.ProductCacheRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductLikeWarmUp {
+  private final ProductRepository productRepository;
+  private final ProductCacheRepository cacheRepository;
+  private final ObjectMapper objectMapper;
+
+  private final String KEY = "product:rank:10";
+
+  @Scheduled(cron = "* */5 * * * *")
+  public void runTaskWithCron() {
+    log.info("Cron 스케쥴 작업 실행: {}", LocalDateTime.now());
+
+    ProductCommand command = ProductCommand.builder()
+        .sort(SortOption.LIKES_DESC)
+        .build();
+    PageRequest page = PageRequest.of(command.currentPage(), command.perSize());
+    Page<ProductProjection> search = productRepository.search(command.toCriteria(), page);
+    List<ProductProjection> content = search.getContent();
+
+    // 내용물이 없으면 캐싱하지 않는다.
+    if (content.isEmpty()) {
+      return;
+    }
+
+    // 초기화
+    cacheRepository.remove(KEY);
+
+    String value;
+    try {
+      value = objectMapper.writeValueAsString(search.getContent());
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+
+    cacheRepository.put(KEY, value, Duration.ofMinutes(10));
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductLikeWarmUp.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductLikeWarmUp.java
@@ -21,38 +21,11 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ProductLikeWarmUp {
-  private final ProductRepository productRepository;
-  private final ProductCacheRepository cacheRepository;
-  private final ObjectMapper objectMapper;
-
-  private final String KEY = "product:rank:10";
+  private final ProductWarmupProcessor warmupProcessor;
 
   @Scheduled(cron = "* */5 * * * *")
   public void runTaskWithCron() {
     log.info("Cron 스케쥴 작업 실행: {}", LocalDateTime.now());
-
-    ProductCommand command = ProductCommand.builder()
-        .sort(SortOption.LIKES_DESC)
-        .build();
-    PageRequest page = PageRequest.of(command.currentPage(), command.perSize());
-    Page<ProductProjection> search = productRepository.search(command.toCriteria(), page);
-    List<ProductProjection> content = search.getContent();
-
-    // 내용물이 없으면 캐싱하지 않는다.
-    if (content.isEmpty()) {
-      return;
-    }
-
-    // 초기화
-    cacheRepository.remove(KEY);
-
-    String value;
-    try {
-      value = objectMapper.writeValueAsString(search.getContent());
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-
-    cacheRepository.put(KEY, value, Duration.ofMinutes(10));
+    warmupProcessor.warmup();
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductLikeWarmUp.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductLikeWarmUp.java
@@ -1,19 +1,8 @@
 package com.loopers.application.catalog.product.warmup;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.loopers.application.catalog.product.ProductCommand;
-import com.loopers.application.catalog.product.SortOption;
-import com.loopers.domain.catalog.product.ProductProjection;
-import com.loopers.domain.catalog.product.ProductRepository;
-import com.loopers.domain.catalog.product.cache.ProductCacheRepository;
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductWarmupProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductWarmupProcessor.java
@@ -1,0 +1,81 @@
+package com.loopers.application.catalog.product.warmup;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.catalog.product.ProductCommand;
+import com.loopers.application.catalog.product.SortOption;
+import com.loopers.domain.catalog.product.ProductProjection;
+import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.domain.catalog.product.cache.ProductCacheRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductWarmupProcessor {
+  private final ProductCacheRepository cacheRepository;
+  private final ProductRepository productRepository;
+
+  private final String KEY = "product:rank:10";
+
+  public void warmup() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    String productRankValue = cacheRepository.get(KEY);
+    if (productRankValue != null) {
+      log.info("TTL 강제 초기화");
+      cacheRepository.remove(KEY);
+    }
+
+    ProductCommand command = ProductCommand.builder()
+        .perSize(10)
+        .currentPage(0)
+        .sort(SortOption.LIKES_DESC)
+        .build();
+
+    Page<ProductProjection> search = productRepository.search(command.toCriteria(), PageRequest.of(0, 10));
+    String value;
+    try {
+      value = objectMapper.writeValueAsString(search.getContent());
+    } catch (JsonProcessingException e) {
+      throw new CoreException(ErrorType.INTERNAL_ERROR, "json parse error : " + e.getMessage());
+    }
+
+    log.info("warm up data : {}", value);
+    cacheRepository.put(KEY, value, Duration.ofMinutes(10));
+  }
+
+  public Page<ProductProjection> searchData(ProductCommand command) {
+    PageRequest page = PageRequest.of(command.currentPage(), command.perSize());
+    // 1. 캐시 사용 조건(좋아요순 정렬)이면서 캐시에 값이 실제로 존재할 때만 캐시 로직 실행
+    if (command.sort() == SortOption.LIKES_DESC) {
+      String value = cacheRepository.get(KEY);
+      if (value != null) {
+        log.info("cache hit");
+        try {
+          List<ProductProjection> cacheContent = new ObjectMapper().readValue(value, new TypeReference<>() {
+          });
+          // 캐시 처리 성공 시, 여기서 결과를 바로 반환하고 메서드를 종료합니다.
+          return new PageImpl<>(cacheContent, Pageable.ofSize(10), 10);
+        } catch (JsonProcessingException e) {
+          throw new CoreException(ErrorType.INTERNAL_ERROR, "json parse error : " + e.getMessage());
+        }
+      }
+      // '좋아요순'이지만 캐시에 값이 없는 경우 (cache miss)
+      log.info("cache miss");
+    }
+    // 2. 위 if 블록의 조건을 만족하지 못한 모든 경우 (캐시를 사용하지 않는 정렬 or 캐시 미스)
+    // 이 코드가 실행된다는 것은 DB 조회가 필요하다는 의미입니다.
+    return productRepository.search(command.toCriteria(), page);
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductWarmupProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/product/warmup/ProductWarmupProcessor.java
@@ -52,7 +52,7 @@ public class ProductWarmupProcessor {
     }
 
     log.info("warm up data : {}", value);
-    cacheRepository.put(KEY, value, Duration.ofMinutes(10));
+    cacheRepository.put(KEY, value, Duration.ofDays(1));
   }
 
   public Page<ProductProjection> searchData(ProductCommand command) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductModel.java
@@ -28,12 +28,6 @@ public class ProductModel extends BaseEntity {
   @Column(columnDefinition = "TEXT")
   private String description;
 
-  @OneToOne
-  private ProductStatus status;
-
-  @OneToOne
-  private StockModel stock;
-
   public ProductModel(Long brandId, String name, BigInteger price, String description) {
     this.brandId = brandId;
     this.name = ProductName.of(name);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductProjection.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/ProductProjection.java
@@ -5,9 +5,11 @@ import java.math.BigInteger;
 import java.time.ZonedDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
+@ToString
 public class ProductProjection {
   private Long id;
   private Long brandId;
@@ -16,13 +18,11 @@ public class ProductProjection {
   private BigInteger price;
   private String description;
   private int likedCount;
-  private ZonedDateTime createdAt;
-  private ZonedDateTime updateAt;
 
 
   @QueryProjection
   public ProductProjection(Long id, Long brandId, String brandName, String name, BigInteger price, String description,
-                           int likedCount, ZonedDateTime createdAt, ZonedDateTime updateAt) {
+                           int likedCount) {
     this.id = id;
     this.brandId = brandId;
     this.brandName = brandName;
@@ -30,7 +30,5 @@ public class ProductProjection {
     this.price = price;
     this.description = description;
     this.likedCount = likedCount;
-    this.createdAt = createdAt;
-    this.updateAt = updateAt;
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/cache/ProductCacheRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/cache/ProductCacheRepository.java
@@ -6,4 +6,6 @@ public interface ProductCacheRepository {
   void put(String key, String value, Duration duration);
 
   String get(String key);
+
+  void remove(String key);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/cache/ProductCacheRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/cache/ProductCacheRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.catalog.product.cache;
+
+import java.time.Duration;
+
+public interface ProductCacheRepository {
+  void put(String key, String value, Duration duration);
+
+  String get(String key);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/status/ProductStatusRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/catalog/product/status/ProductStatusRepository.java
@@ -1,0 +1,4 @@
+package com.loopers.domain.catalog.product.status;
+
+public interface ProductStatusRepository {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductRepositoryImpl.java
@@ -82,6 +82,7 @@ public class ProductRepositoryImpl implements ProductRepository {
               case PRICE_ASC -> product.price.price.asc();
               case LIKES_DESC -> status.likeCount.desc();
             })
+        .orderBy(product.id.asc())
         .fetch();
 
     // 갯수

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/ProductRepositoryImpl.java
@@ -67,9 +67,7 @@ public class ProductRepositoryImpl implements ProductRepository {
                 product.name.name,
                 product.price.price,
                 product.description,
-                status.likeCount,
-                product.createdAt,
-                product.updatedAt))
+                status.likeCount))
         .from(product)
         .leftJoin(brand).on(product.brandId.eq(brand.id))
         .leftJoin(status).on(status.productId.eq(product.id))
@@ -112,9 +110,7 @@ public class ProductRepositoryImpl implements ProductRepository {
                         product.name.name,
                         product.price.price,
                         product.description,
-                        status.likeCount,
-                        product.createdAt,
-                        product.updatedAt))
+                        status.likeCount))
                 .from(product)
                 .leftJoin(brand).on(product.brandId.eq(brand.id))
                 .leftJoin(status).on(status.productId.eq(product.id))

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/cache/ProductCacheRankRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/cache/ProductCacheRankRepositoryImpl.java
@@ -21,4 +21,8 @@ public class ProductCacheRankRepositoryImpl implements ProductCacheRepository {
   public String get(String key) {
     return redisTemplate.opsForValue().get(key);
   }
+
+  public void remove(String key) {
+    redisTemplate.delete(key);
+  }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/cache/ProductCacheRankRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/cache/ProductCacheRankRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.catalog.product.cache;
+
+import com.loopers.domain.catalog.product.cache.ProductCacheRepository;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductCacheRankRepositoryImpl implements ProductCacheRepository {
+  private final RedisTemplate<String, String> redisTemplate;
+
+
+  @Override
+  public void put(String key, String value, Duration duration) {
+    redisTemplate.opsForValue().set(key, value, duration);
+  }
+
+  @Override
+  public String get(String key) {
+    return redisTemplate.opsForValue().get(key);
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/status/ProductStatusJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/status/ProductStatusJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.catalog.product.status;
+
+import com.loopers.domain.catalog.product.status.ProductStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductStatusJpaRepository extends JpaRepository<ProductStatus, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/status/ProductStatusRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/catalog/product/status/ProductStatusRepositoryImpl.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.catalog.product.status;
+
+import com.loopers.domain.catalog.product.status.ProductStatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductStatusRepositoryImpl implements ProductStatusRepository {
+  private final ProductStatusJpaRepository  productStatusJpaRepository;
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.like.LikeV1Dto.Register.Response;
+import com.loopers.interfaces.api.like.LikeV1Dto.Unregister;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Like V1 API", description = "Like API 입니다.")
+public interface LikeV1ApiSpec {
+
+  @Operation(
+      summary = "좋아요 등록",
+      description = "상품에 좋아요를 합니다."
+  )
+  ApiResponse<Response> register(
+      @Schema(name = "계정 아이디", description = "좋아요를 누를 계정의 아이디") String userId,
+      @Schema(name = "상품 아이디", description = "좋아요를 누릴 상품의 아이디") Long productId);
+
+  @Operation(
+      summary = "좋아요 해제",
+      description = "좋아요가 지정된 상품의 좋아요를 해제합니다."
+  )
+  ApiResponse<Unregister.Response> unregister(
+      @Schema(name = "계정 아이디", description = "좋아요를 해제할 계정의 아이디") String userId,
+      @Schema(name = "상품 아이디", description = "좋아요를 해제될 상품의 아이디") Long productId);
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -1,11 +1,13 @@
 package com.loopers.interfaces.api.like;
 
+import com.loopers.application.like.LikeFacade;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.like.LikeV1Dto.Get;
 import com.loopers.interfaces.api.like.LikeV1Dto.Get.Contents;
 import com.loopers.interfaces.api.like.LikeV1Dto.Register.Response;
 import com.loopers.interfaces.api.like.LikeV1Dto.Unregister;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,36 +18,33 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/like/products")
+@RequiredArgsConstructor
 public class LikeV1Controller {
+  private final LikeFacade likeFacade;
 
   @PostMapping("/{productId}")
-  public ApiResponse<LikeV1Dto.Register.Response> register(
+  public ApiResponse<Response> register(
       @RequestHeader("X-User-Id") String userId,
       @PathVariable Long productId) {
-    return ApiResponse.success(new Response(
-        userId,
-        productId,
-        true
-    ));
+    likeFacade.like(userId, productId);
+    return ApiResponse.success(Response.from(userId, productId));
   }
 
   @DeleteMapping("/{productId}")
-  public ApiResponse<LikeV1Dto.Unregister.Response> unregister(
+  public ApiResponse<Unregister.Response> unregister(
       @RequestHeader("X-User-Id") String userId,
       @PathVariable Long productId) {
-    return ApiResponse.success(new Unregister.Response(
-        userId,
-        productId,
-        false));
+    likeFacade.unlike(userId, productId);
+    return ApiResponse.success(Unregister.Response.from(userId, productId));
   }
 
   @GetMapping()
   public ApiResponse<LikeV1Dto.Get.Response> get(
       @RequestHeader("X-User-Id") String userId) {
     return ApiResponse.success(new Get.Response(
-        List.of(new Contents(1L,"상품1"),
-            new Contents(1L,"상품1")),
-        1,1,1,1
+        List.of(new Contents(1L, "상품1"),
+            new Contents(1L, "상품1")),
+        1, 1, 1, 1
     ));
   }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -19,9 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/like/products")
 @RequiredArgsConstructor
-public class LikeV1Controller {
+public class LikeV1Controller implements LikeV1ApiSpec {
   private final LikeFacade likeFacade;
 
+  @Override
   @PostMapping("/{productId}")
   public ApiResponse<Response> register(
       @RequestHeader("X-User-Id") String userId,
@@ -30,6 +31,7 @@ public class LikeV1Controller {
     return ApiResponse.success(Response.from(userId, productId));
   }
 
+  @Override
   @DeleteMapping("/{productId}")
   public ApiResponse<Unregister.Response> unregister(
       @RequestHeader("X-User-Id") String userId,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -5,11 +5,22 @@ import java.util.List;
 
 public class LikeV1Dto {
 
-  class Register {
-    record Response(String userId, Long productId, boolean status) {}
+  static class Register {
+    record Response(String userId, Long productId, boolean status) {
+
+      public static Response from(String userId, Long productId) {
+        return new Response(userId, productId, true);
+      }
+
+    }
   }
+
   class Unregister {
-    record Response(String userId, Long productId, boolean status) {}
+    record Response(String userId, Long productId, boolean status) {
+      public static Response from(String userId, Long productId) {
+        return new Unregister.Response(userId, productId, false);
+      }
+    }
   }
 
 
@@ -18,8 +29,11 @@ public class LikeV1Dto {
                     int page,
                     int size,
                     int totalElements,
-                    int totalPages) {}
-    record Contents(Long productId, String productName) {}
+                    int totalPages) {
+    }
+
+    record Contents(Long productId, String productName) {
+    }
   }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.product.ProductV1Dto.Search.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Product V1 API", description = "Product API 입니다.")
+public interface ProductV1ApiSpec {
+
+  @Operation(
+      summary = "검색",
+      description = "상품을 검색 합니다."
+  )
+  ApiResponse<Response> search(
+      @Schema(name = "브랜드 아이디", description = "특정 브랜드 아이디에 해당하는 상품 리스트 조회") Long brandId,
+      @Schema(name = "브랜드 명", description = "특정 브랜드 명에 해당하는 상품 리스트 조회") String brandName,
+      @Schema(name = "상품 명", description = "특정 상품 명에 해당하는 상품 리스트 조회") String productName,
+      @Schema(name = "정렬 조건", description = "검색에 활용되어지는 정렬 조건") String sort,
+      @Schema(name = "현재 페이지", description = "검색할 페이지") Integer currentPage,
+      @Schema(name = "필요 갯수", description = "검색되어지는 상품 갯수") Integer perSize);
+
+  @Operation(
+      summary = "조회",
+      description = "상품을 단일 조회합니다."
+  )
+  ApiResponse<ProductV1Dto.Get.Response> get(
+      @Schema(name = "상품 ID", description = "상세 조회할 상품의 ID")
+      Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Condition.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Condition.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.catalog.product.ProductCommand;
+import com.loopers.application.catalog.product.SortOption;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductV1Condition {
+  private Long brandId;
+  private String brandName;
+  private String productName;
+  private String sort;
+  private Integer currentPage;
+  private Integer perSize;
+
+  public ProductCommand toCommand() {
+    return new ProductCommand(
+        brandId,
+        brandName,
+        productName,
+        sort == null ? null : SortOption.valueOf(sort),
+        currentPage,
+        perSize);
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Condition.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Condition.java
@@ -18,12 +18,13 @@ public class ProductV1Condition {
   private Integer perSize;
 
   public ProductCommand toCommand() {
-    return new ProductCommand(
-        brandId,
-        brandName,
-        productName,
-        sort == null ? null : SortOption.valueOf(sort),
-        currentPage,
-        perSize);
+    return ProductCommand.builder()
+        .brandId(brandId)
+        .brandName(brandName)
+        .productName(productName)
+        .sort(sort == null ? null : SortOption.valueOf(sort))
+        .currentPage(currentPage)
+        .perSize(perSize)
+        .build();
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -4,26 +4,41 @@ import com.loopers.application.catalog.product.ProductFacade;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/products")
 @RequiredArgsConstructor
-public class ProductV1Controller {
+public class ProductV1Controller implements ProductV1ApiSpec {
   private final ProductFacade productFacade;
 
+  @Override
   @GetMapping
   public ApiResponse<ProductV1Dto.Search.Response> search(
-      @ModelAttribute ProductV1Condition condition
+
+      @RequestParam(required = false) Long brandId,
+      @RequestParam(required = false) String brandName,
+      @RequestParam(required = false) String productName,
+      @RequestParam(required = false) String sort,
+      @RequestParam(required = false) Integer currentPage,
+      @RequestParam(required = false) Integer perSize
   ) {
+    ProductV1Condition condition = ProductV1Condition.builder()
+        .brandId(brandId)
+        .brandName(brandName)
+        .productName(productName)
+        .sort(sort)
+        .currentPage(currentPage)
+        .perSize(perSize).build();
     return ApiResponse.success(
         ProductV1Dto.Search.Response.from(productFacade.search(condition.toCommand()))
     );
   }
 
+  @Override
   @GetMapping("/{productId}")
   public ApiResponse<ProductV1Dto.Get.Response> get(@PathVariable Long productId) {
     return ApiResponse.success(ProductV1Dto.Get.Response.from(productFacade.get(productId)));

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -5,6 +5,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,4 +44,12 @@ public class ProductV1Controller implements ProductV1ApiSpec {
   public ApiResponse<ProductV1Dto.Get.Response> get(@PathVariable Long productId) {
     return ApiResponse.success(ProductV1Dto.Get.Response.from(productFacade.get(productId)));
   }
+
+  @PostMapping ("/rank")
+  public ApiResponse<?> rank() {
+    productFacade.rank();
+    return ApiResponse.success();
+  }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -1,37 +1,31 @@
 package com.loopers.interfaces.api.product;
 
+import com.loopers.application.catalog.product.ProductFacade;
 import com.loopers.interfaces.api.ApiResponse;
-import com.loopers.interfaces.api.product.ProductV1Dto.Search.Contents;
-import java.math.BigInteger;
-import java.time.LocalDateTime;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
 public class ProductV1Controller {
-
+  private final ProductFacade productFacade;
 
   @GetMapping
-  public ApiResponse<ProductV1Dto.Search.Response> search() {
+  public ApiResponse<ProductV1Dto.Search.Response> search(
+      @ModelAttribute ProductV1Condition condition
+  ) {
     return ApiResponse.success(
-        new ProductV1Dto.Search.Response(
-            List.of(new Contents(1L,"상품1"),new Contents(2L,"상품2")),
-            1,1,1,1
-        )
+        ProductV1Dto.Search.Response.from(productFacade.search(condition.toCommand()))
     );
   }
 
   @GetMapping("/{productId}")
-  public ApiResponse<ProductV1Dto.Get.Response> search(@PathVariable Long productId) {
-    return ApiResponse.success(
-        new ProductV1Dto.Get.Response(
-            productId,"상품1", BigInteger.valueOf(2000),"이건 검정색이고 암튼 좋아요",
-            LocalDateTime.now(),LocalDateTime.now()
-        )
-    );
+  public ApiResponse<ProductV1Dto.Get.Response> get(@PathVariable Long productId) {
+    return ApiResponse.success(ProductV1Dto.Get.Response.from(productFacade.get(productId)));
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -1,30 +1,64 @@
 package com.loopers.interfaces.api.product;
 
+import com.loopers.application.catalog.product.ProductContents;
+import com.loopers.application.catalog.product.ProductGetInfo;
+import com.loopers.application.catalog.product.ProductSearchInfo;
 import java.math.BigInteger;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
+import lombok.Builder;
 
 public class ProductV1Dto {
 
-  class Search {
+  static class Search {
+    @Builder
     record Response(List<Contents> contents,
                     int page,
                     int size,
                     int totalElements,
                     int totalPages) {
 
+      public static Response from(ProductSearchInfo search) {
+
+        return Response.builder()
+            .contents(
+                search.contents().stream().map(Contents::new).toList()
+            )
+            .page(search.page())
+            .size(search.size())
+            .totalElements(search.totalElements())
+            .totalPages(search.totalPages())
+            .build();
+      }
     }
 
-    record Contents(Long id, String name) {
+    record Contents(Long id, String name, int likeCount) {
 
+      public Contents(ProductContents contents) {
+        this(contents.id(), contents.name(), contents.likeCount());
+      }
     }
 
 
   }
 
-  class Get {
-    record Response(Long id, String name, BigInteger price, String description,
-    LocalDateTime createdAt, LocalDateTime updatedAt) {}
+
+  static class Get {
+    record Response(Long productId,
+                    String brandName,
+                    String productName,
+                    BigInteger price,
+                    int likedCount,
+                    String description,
+                    ZonedDateTime createdAt,
+                    ZonedDateTime updatedAt) {
+
+      public static Response from(ProductGetInfo productGetInfo) {
+        return new Response(productGetInfo.productId(), productGetInfo.brandName(), productGetInfo.productName(),
+            productGetInfo.price(),
+            productGetInfo.likedCount(), productGetInfo.description(), productGetInfo.createdAt(), productGetInfo.updatedAt());
+      }
+    }
   }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -15,7 +15,7 @@ public class ProductV1Dto {
     record Response(List<Contents> contents,
                     int page,
                     int size,
-                    int totalElements,
+                    long totalElements,
                     int totalPages) {
 
       public static Response from(ProductSearchInfo search) {

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
   config:
     import:
       - jpa.yml
+      - redis.yml
       - logging.yml
       - monitoring.yml
 

--- a/apps/commerce-api/src/main/resources/sql/create_index_brand_id_product.sql
+++ b/apps/commerce-api/src/main/resources/sql/create_index_brand_id_product.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_brand_id ON product (brand_id);

--- a/apps/commerce-api/src/main/resources/sql/create_index_like_brand_prdocut.sql
+++ b/apps/commerce-api/src/main/resources/sql/create_index_like_brand_prdocut.sql
@@ -1,2 +1,3 @@
-CREATE INDEX idx_brand_id_and_id ON product (brand_id, id);
-CREATE INDEX idx_product_id_and_like_count ON product_status (product_id DESC, like_count DESC);
+CREATE INDEX idx_ps_like_count_product  ON product_status (like_count DESC, product_id);
+CREATE INDEX idx_product_brand_id ON product (brand_id);
+CREATE INDEX idx_stock_product_id ON stock (product_id);

--- a/apps/commerce-api/src/main/resources/sql/create_index_like_brand_prdocut.sql
+++ b/apps/commerce-api/src/main/resources/sql/create_index_like_brand_prdocut.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_brand_id_and_id ON product (brand_id, id);
+CREATE INDEX idx_product_id_and_like_count ON product_status (product_id DESC, like_count DESC);

--- a/apps/commerce-api/src/main/resources/sql/create_index_like_count_product_status.sql
+++ b/apps/commerce-api/src/main/resources/sql/create_index_like_count_product_status.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_like_count ON product_status (like_count DESC);

--- a/apps/commerce-api/src/main/resources/sql/drop_index_brand_id_product.sql
+++ b/apps/commerce-api/src/main/resources/sql/drop_index_brand_id_product.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_brand_id ON product;

--- a/apps/commerce-api/src/main/resources/sql/drop_index_like_brand_prdocut.sql
+++ b/apps/commerce-api/src/main/resources/sql/drop_index_like_brand_prdocut.sql
@@ -1,0 +1,2 @@
+drop INDEX idx_brand_id_and_id ON product;
+drop INDEX idx_product_id_and_like_count ON product_status;

--- a/apps/commerce-api/src/main/resources/sql/drop_index_like_count_product_status.sql
+++ b/apps/commerce-api/src/main/resources/sql/drop_index_like_count_product_status.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_like_count ON product_status;

--- a/apps/commerce-api/src/main/resources/sql/explain.sql
+++ b/apps/commerce-api/src/main/resources/sql/explain.sql
@@ -1,0 +1,19 @@
+explain SELECT
+            p.id,
+            p.brand_id,
+            b.name,
+            p.name,
+            p.price,
+            p.description,
+            ps.like_count,
+            p.created_at,
+            p.updated_at
+        FROM product p
+                 inner join brand b
+                            on p.brand_id = b.id
+                 inner join stock s
+                            on p.id = s.product_id
+                 inner join product_status ps
+                            on p.id = ps.product_id
+        order by ps.like_count desc
+        limit 0,10;

--- a/apps/commerce-api/src/test/java/com/loopers/application/catalog/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/catalog/product/ProductServiceIntegrationTest.java
@@ -161,26 +161,6 @@ class ProductServiceIntegrationTest {
     }
 
 
-    @DisplayName("생성일 기준으로 조회하는 경우, 해당하는 상품 리스트가 조회됩니다.")
-    @Test
-    void returnProductList_whenSortingCreatedAt() {
-      //given
-      ProductCommand command = ProductCommand.builder()
-          .sort(SortOption.LATEST) // 기본값은 LATEST
-          .currentPage(0)
-          .perSize(3)
-          .build();
-      //when
-      ProductSearchInfo search = productFacade.search(command);
-      List<ProductContents> contents = search.contents();
-      ProductContents preContents = contents.getFirst();
-      //then
-      for (int i = 1; i < contents.size(); i++) {
-        ProductContents nextModel = contents.get(i);
-        assertThat(preContents.createdAt()).isAfterOrEqualTo(nextModel.createdAt());
-        preContents = nextModel;
-      }
-    }
 
     @DisplayName("가격을 기준으로 조회하는 경우, 해당하는 상품 리스트가 조회됩니다.(오름차순)")
     @Test
@@ -259,8 +239,6 @@ class ProductServiceIntegrationTest {
         assertThat(productGetInfo.brandName()).isEqualTo(productModel.getBrandName());
         assertThat(productGetInfo.price()).isEqualTo(productModel.getPrice());
         assertThat(productGetInfo.likedCount()).isEqualTo(count);
-        assertThat(productGetInfo.createdAt()).isEqualTo(productModel.getCreatedAt());
-        assertThat(productGetInfo.updatedAt()).isEqualTo(productModel.getUpdateAt());
         assertThat(productGetInfo.description()).isEqualTo(productModel.getDescription());
         System.out.println(productGetInfo);
       }

--- a/apps/commerce-api/src/test/java/com/loopers/application/catalog/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/catalog/product/ProductServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.loopers.domain.catalog.product.ProductProjection;
 import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.infrastructure.catalog.brand.BrandJpaRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -33,6 +34,9 @@ class ProductServiceIntegrationTest {
   private ProductFacade productFacade;
   @Autowired
   private ProductRepository repository;
+
+  @Autowired
+  private BrandJpaRepository brandRepository;
 
   @Autowired
   private DatabaseCleanUp databaseCleanUp;
@@ -108,8 +112,9 @@ class ProductServiceIntegrationTest {
       //then
       List<ProductContents> content = search.contents();
 
+      String brandName = brandRepository.findById(1L).get().getName();
       for (ProductContents productModel : content) {
-        assertThat(productModel.brandId()).isEqualTo(command.brandId());
+        assertThat(productModel.brandName()).isEqualTo(brandName);
       }
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/catalog/product/warmup/ProductWarmupProcessorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/catalog/product/warmup/ProductWarmupProcessorTest.java
@@ -1,0 +1,47 @@
+package com.loopers.application.catalog.product.warmup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.loopers.application.catalog.product.ProductCommand;
+import com.loopers.application.catalog.product.SortOption;
+import com.loopers.domain.catalog.product.ProductRepository;
+import com.loopers.domain.catalog.product.cache.ProductCacheRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest
+@Sql("/sql/test-fixture.sql")
+class ProductWarmupProcessorTest {
+
+  @Autowired
+  private ProductCacheRepository productCacheRepository;
+
+  @Autowired
+  private ProductRepository productRepository;
+
+  @Autowired
+  private ProductWarmupProcessor productWarmupProcessor;
+
+
+  @Test
+  @DisplayName("좋아요 순위를 warm up을 하면, 캐시 정보에 저장이 되어집니다.")
+  void returnCacheInfo_whenStatedLikeLankWarmup() {
+    String key = "product:rank:10";
+    //given
+    ProductCommand productCommand = ProductCommand.builder()
+        .currentPage(0)
+        .perSize(10)
+        .sort(SortOption.LIKES_DESC)
+        .build();
+    PageRequest request = PageRequest.of(0, 10);
+    productRepository.search(productCommand.toCriteria(), request);
+    //when
+    productWarmupProcessor.warmup();
+    //then
+    assertThat(productCacheRepository.get(key)).isNotEmpty();
+  }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderServiceIntegrationTest.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -137,63 +136,5 @@ class OrderServiceIntegrationTest {
     assertThat(cancel.orderStaus()).isEqualTo("CANCEL");
   }
 
-  @DisplayName("주문시 포인트 확인,")
-  @Nested
-  class Point {
-
-    @DisplayName("주문 시 유저의 포인트 잔액이 부족할 경우 `400 Bad Request`를 반환한다.")
-    @Test
-    void throw400_whenUserHasLessPointsThanOrderRequires() {
-      //given
-      List<OrderItemCommands> orderItemModels = new ArrayList<>();
-
-      orderItemModels.add(new OrderItemCommands(
-          1L, 1L
-      ));
-
-      OrderCreateCommand command =
-          new OrderCreateCommand("userId",
-              "서울시 송파구"
-              , orderItemModels, "메모..");
-
-      pointRepository.save(new PointModel("userId", BigInteger.valueOf(1)));
-
-      //when
-      CoreException result = assertThrows(CoreException.class, () -> orderFacade.create(command));
-      //then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
-
-    }
-  }
-
-  @DisplayName("주문시, 재고 확인")
-  @Nested
-  class Stock {
-
-    @DisplayName("주문 시 재고가 부족할 경우 `400 Bad Request`를 반환한다.")
-    @Test
-    void throw400_whenCreatingOrderWithInsufficientStock() {
-      //given
-      List<OrderItemCommands> orderItemModels = new ArrayList<>();
-
-      orderItemModels.add(new OrderItemCommands(
-          1L, 3000L
-      ));
-
-      OrderCreateCommand command =
-          new OrderCreateCommand("userId",
-              "서울시 송파구"
-              , orderItemModels, "메모..");
-
-      pointRepository.save(new PointModel("userId", BigInteger.valueOf(500000000)));
-
-      //when
-      CoreException result = assertThrows(CoreException.class, () -> orderFacade.create(command));
-      //then
-      assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
-
-    }
-
-  }
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductModelV1ControllerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductModelV1ControllerTest.java
@@ -5,8 +5,17 @@ import static com.loopers.interfaces.api.ApiResponse.Metadata.Result.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.loopers.domain.catalog.brand.BrandModel;
+import com.loopers.domain.catalog.product.ProductModel;
+import com.loopers.domain.catalog.product.status.ProductStatus;
+import com.loopers.domain.catalog.product.stock.StockModel;
+import com.loopers.infrastructure.catalog.brand.BrandJpaRepository;
+import com.loopers.infrastructure.catalog.product.ProductJpaRepository;
+import com.loopers.infrastructure.catalog.product.status.ProductStatusJpaRepository;
+import com.loopers.infrastructure.catalog.product.stock.StockJpaRepository;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigInteger;
 import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,21 +28,33 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ProductModelV1ControllerTest {
 
-  private static final String ENDPOINT = "/api/v1/products/";
+
+  private static final String ENDPOINT = "/api/v1/products";
   private final TestRestTemplate testRestTemplate;
   private final DatabaseCleanUp databaseCleanUp;
 
+  private final BrandJpaRepository brandRepository;
+  private final ProductJpaRepository productRepository;
+  private final StockJpaRepository stockRepository;
+  private final ProductStatusJpaRepository productStatusJpaRepository;
+
+
   @Autowired
-  public ProductModelV1ControllerTest(
-      TestRestTemplate testRestTemplate,
-      DatabaseCleanUp databaseCleanUp
-  ) {
+  public ProductModelV1ControllerTest(TestRestTemplate testRestTemplate, DatabaseCleanUp databaseCleanUp,
+                                      BrandJpaRepository brandRepository, ProductJpaRepository productRepository,
+                                      StockJpaRepository stockRepository,
+                                      ProductStatusJpaRepository productStatusJpaRepository) {
     this.testRestTemplate = testRestTemplate;
     this.databaseCleanUp = databaseCleanUp;
+    this.brandRepository = brandRepository;
+    this.productRepository = productRepository;
+    this.stockRepository = stockRepository;
+    this.productStatusJpaRepository = productStatusJpaRepository;
   }
 
   @AfterEach
@@ -44,30 +65,44 @@ class ProductModelV1ControllerTest {
   @DisplayName("GET /api/v1/products")
   @Nested
   class List {
+    @DisplayName("필터링 조건을 지정하지 않는다면, 모든 상품을 리스토로 리턴합니다.")
+    @Test
+    public void returnAllProducts_whenNonFiltering() {
+      //given
+      BrandModel brandModel = brandRepository.save(new BrandModel("userId", "브랜드 명"));
 
-//    @DisplayName("필터링 조건을 지정하지 않는다면, 모든 상품을 리스토로 리턴합니다.")
-//    @Test
-//    public void returnAllProducts_whenNonFiltering() {
-//      //given
-//
-//      //when
-//      ParameterizedTypeReference<ApiResponse<ProductV1Dto.Search.Response>> responseType = new ParameterizedTypeReference<>() {
-//      };
-//
-//      ResponseEntity<ApiResponse<ProductV1Dto.Search.Response>> response =
-//          testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, new HttpEntity<>(null), responseType);
-//      //then
-//      assertAll(
-//          () -> assertThat(response.getStatusCode().is2xxSuccessful()).isTrue(),
-//          () -> assertThat(response.getBody().meta().result()).isEqualTo(SUCCESS)
-//      );
-//    }
+      ProductModel productModel1 = productRepository.save(new ProductModel(brandModel.getId(), "상품1", BigInteger.valueOf(2000), "상품 설명"));
+      ProductModel productModel2 = productRepository.save(new ProductModel(brandModel.getId(), "상품2", BigInteger.valueOf(20000), "상품 설명2"));
+      ProductModel productModel3 = productRepository.save(new ProductModel(brandModel.getId(), "상품3", BigInteger.valueOf(3000), "상품 설명2"));
+
+      stockRepository.save(new StockModel(productModel1.getId(), 100L));
+      stockRepository.save(new StockModel(productModel2.getId(), 200L));
+      stockRepository.save(new StockModel(productModel3.getId(), 300L));
+
+      productStatusJpaRepository.save(ProductStatus.of(productModel1.getId(), 0));
+      productStatusJpaRepository.save(ProductStatus.of(productModel2.getId(), 0));
+      productStatusJpaRepository.save(ProductStatus.of(productModel3.getId(), 0));
+      //when
+      ParameterizedTypeReference<ApiResponse<ProductV1Dto.Search.Response>> responseType = new ParameterizedTypeReference<>() {
+      };
+
+      String url = UriComponentsBuilder.fromUriString(ENDPOINT)
+          .toUriString();
+
+      ResponseEntity<ApiResponse<ProductV1Dto.Search.Response>> response =
+          testRestTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(null), responseType);
+      //then
+      assertAll(
+          () -> assertThat(response.getStatusCode().is2xxSuccessful()).isTrue(),
+          () -> assertThat(response.getBody().meta().result()).isEqualTo(SUCCESS)
+      );
+    }
   }
 
   @DisplayName("GET /api/v1/products/{productId}")
   @Nested
-  class Get{
-    Function<Long,String> ENDPOINT_GET = id -> ENDPOINT + id;
+  class Get {
+    Function<Long, String> ENDPOINT_GET = id -> ENDPOINT + "/" + id;
 
 
     @DisplayName("상품 ID가 존재하지 않는다면, 404 NotFound Exception을 반환합니다.")
@@ -95,12 +130,19 @@ class ProductModelV1ControllerTest {
     @Test
     public void returnProductInfo_whenProductId() {
       //given
-      Long id = 1L;
+      BrandModel brandModel = brandRepository.save(new BrandModel("userId", "브랜드 명"));
+
+      ProductModel productModel = productRepository.save(new ProductModel(brandModel.getId(), "상품1", BigInteger.valueOf(2000), "상품 설명"));
+
+      stockRepository.save(new StockModel(productModel.getId(), 100L));
+
+      productStatusJpaRepository.save(ProductStatus.of(productModel.getId(), 0));
+
       //when
       ParameterizedTypeReference<ApiResponse<ProductV1Dto.Get.Response>> responseType = new ParameterizedTypeReference<>() {
       };
 
-      String endpoint = ENDPOINT_GET.apply(id);
+      String endpoint = ENDPOINT_GET.apply(productModel.getId());
 
       ResponseEntity<ApiResponse<ProductV1Dto.Get.Response>> response =
           testRestTemplate.exchange(endpoint, HttpMethod.GET, new HttpEntity<>(null), responseType);
@@ -109,7 +151,7 @@ class ProductModelV1ControllerTest {
       assertAll(
           () -> assertThat(response.getStatusCode().is2xxSuccessful()).isTrue(),
           () -> assertThat(response.getBody().meta().result()).isEqualTo(SUCCESS),
-          () -> assertThat(response.getBody().data().id()).isEqualTo(id)
+          () -> assertThat(response.getBody().data().productId()).isEqualTo(1L)
       );
     }
 

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -1,21 +1,54 @@
 version: '3'
 services:
-  mysql:
-    image: mysql:8.0
+  redis-master:
+    image: redis:7.0
+    container_name: redis-master
     ports:
-      - "3306:3306"
-    environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=application
-      - MYSQL_PASSWORD=application
-      - MYSQL_DATABASE=loopers
-      - MYSQL_CHARACTER_SET=utf8mb4
-      - MYSQL_COLLATE=utf8mb4_general_ci
+      - "6379:6379"
     volumes:
-      - mysql-8-data:/var/lib/mysql
+      - redis_master_data:/data
+    command:
+      [
+        "redis-server", # redis 서버 실행 명령어
+        "--appendonly", "yes", # AOF (AppendOnlyFile) 영속성 기능 켜기
+        "--save", "",
+        "--latency-monitor-threshold", "100", # 특정 command 가 지정 시간(ms) 이상 걸리면 monitor 기록
+      ]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "PING"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  redis-readonly:
+    image: redis:7.0
+    container_name: redis-readonly
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis_readonly_data:/data
+    command:
+      [
+        "redis-server",
+        "--appendonly", "yes",
+        "--appendfsync", "everysec",
+        "--replicaof", "redis-master", "6379", # replica 모드로 실행 + 서비스 명, 서비스 포트
+        "--replica-read-only", "yes", # 읽기 전용으로 설정
+        "--latency-monitor-threshold", "100",
+      ]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6380", "PING"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
 
 volumes:
   mysql-8-data:
+  redis_master_data:
+  redis_readonly_data:
 
 networks:
   default:

--- a/docker/k6/search.js
+++ b/docker/k6/search.js
@@ -1,0 +1,20 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// 부하 설정
+export const options = {
+    vus: 10, // 동시에 실행할 가상 사용자 수
+    duration: '60s', // 테스트 시간
+};
+
+export default function () {
+    const url = 'http://host.docker.internal:8080/api/v1/products?currentPage=0&perPage=10&sort=LIKES_DESC'; // 엔드포인트 주소
+    const res = http.get(url);
+
+    // 응답 검증
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1); // 요청 간 대기 시간
+}

--- a/docker/k6/test.js
+++ b/docker/k6/test.js
@@ -1,0 +1,20 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// 부하 설정
+export const options = {
+    vus: 10, // 동시에 실행할 가상 사용자 수
+    duration: '30s', // 테스트 시간
+};
+
+export default function () {
+    const url = 'http://host.docker.internal:8080/api/v1/products'; // 엔드포인트 주소
+    const res = http.get(url);
+
+    // 응답 검증
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1); // 요청 간 대기 시간
+}

--- a/docker/monitoring-compose.yml
+++ b/docker/monitoring-compose.yml
@@ -16,3 +16,25 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
+
+  influxdb:
+    image: influxdb:1.8
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb:/var/lib/influxdb
+    environment:
+      - INFLUXDB_DB=k6
+
+  k6:
+    image: grafana/k6
+    volumes:
+      - ./k6:/scripts
+    depends_on:
+      - influxdb
+    environment:
+      - K6_OUT=influxdb=http://influxdb:8086/k6
+
+volumes:
+  influxdb:
+  grafana:

--- a/modules/jpa/src/main/resources/data.sql
+++ b/modules/jpa/src/main/resources/data.sql
@@ -1,0 +1,58 @@
+-- MySQL을 기준으로 작성된 100만 개의 더미 데이터 생성 스크립트입니다.
+-- MySQL 8.0 이상 버전에서 작동합니다.
+
+-- 재귀 쿼리의 최대 깊이를 1000000으로 설정합니다.
+-- 이 값은 현재 세션에만 적용됩니다.
+SET @@cte_max_recursion_depth = 1000000;
+
+
+-- brand 데이터 삽입
+INSERT INTO brand (user_id, name, created_at, updated_at) VALUES
+                                                              ('user1', '루프스', NOW(), NOW()),
+                                                              ('user2', '소마웨어', NOW(), NOW()),
+                                                              ('user3', '에이블코어', NOW(), NOW()),
+                                                              ('user4', '하이로닉스', NOW(), NOW());
+
+-- 100만 개의 product 더미 데이터 삽입
+INSERT INTO product (brand_id, name, price, description, created_at, updated_at)
+WITH RECURSIVE numbers AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 FROM numbers WHERE n < 1000000
+)
+SELECT
+    FLOOR(1 + RAND() * 4) AS brand_id,
+    CONCAT('Product Name ', n) AS name,
+    FLOOR(100 + RAND() * 1901) * 100 AS price,
+    CONCAT('Description for Product ', n) AS description,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS created_at,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS updated_at
+FROM numbers;
+
+-- 100만 개의 stock 더미 데이터 삽입
+INSERT INTO stock (product_id, stock, created_at, updated_at)
+WITH RECURSIVE numbers AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 FROM numbers WHERE n < 1000000
+)
+SELECT
+    n AS product_id,
+    FLOOR(10 + RAND() * 491) AS stock,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS created_at,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS updated_at
+FROM numbers;
+
+-- 100만 개의 product_status 더미 데이터 삽입
+INSERT INTO product_status (product_id, like_count, created_at, updated_at)
+WITH RECURSIVE numbers AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 FROM numbers WHERE n < 1000000
+)
+SELECT
+    n AS product_id,
+    FLOOR(RAND() * 3001) AS like_count,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS created_at,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS updated_at
+FROM numbers;

--- a/modules/jpa/src/main/resources/data.sql
+++ b/modules/jpa/src/main/resources/data.sql
@@ -1,17 +1,19 @@
--- MySQL을 기준으로 작성된 100만 개의 더미 데이터 생성 스크립트입니다.
--- MySQL 8.0 이상 버전에서 작동합니다.
-
--- 재귀 쿼리의 최대 깊이를 1000000으로 설정합니다.
--- 이 값은 현재 세션에만 적용됩니다.
+-- MySQL 8.0 이상 버전에서 작동
 SET @@cte_max_recursion_depth = 1000000;
 
-
--- brand 데이터 삽입
-INSERT INTO brand (user_id, name, created_at, updated_at) VALUES
-                                                              ('user1', '루프스', NOW(), NOW()),
-                                                              ('user2', '소마웨어', NOW(), NOW()),
-                                                              ('user3', '에이블코어', NOW(), NOW()),
-                                                              ('user4', '하이로닉스', NOW(), NOW());
+-- 10만 개의 brand 더미 데이터 삽입
+INSERT INTO brand (user_id, name, created_at, updated_at)
+WITH RECURSIVE numbers AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 FROM numbers WHERE n < 100000
+)
+SELECT
+    CONCAT('user', n) AS user_id,
+    CONCAT('Brand Name ', n) AS name,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 300 * 24 * 3600), NOW()) AS created_at,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 300 * 24 * 3600), NOW()) AS updated_at
+FROM numbers;
 
 -- 100만 개의 product 더미 데이터 삽입
 INSERT INTO product (brand_id, name, price, description, created_at, updated_at)
@@ -21,12 +23,12 @@ WITH RECURSIVE numbers AS (
     SELECT n + 1 FROM numbers WHERE n < 1000000
 )
 SELECT
-    FLOOR(1 + RAND() * 4) AS brand_id,
+    FLOOR(1 + RAND() * 100000) AS brand_id, -- 브랜드는 1~10만 랜덤
     CONCAT('Product Name ', n) AS name,
-    FLOOR(100 + RAND() * 1901) * 100 AS price,
+    FLOOR(100 + RAND() * 2000000) * 100 AS price,
     CONCAT('Description for Product ', n) AS description,
-    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS created_at,
-    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS updated_at
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 300 * 24 * 3600), NOW()) AS created_at,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 300 * 24 * 3600), NOW()) AS updated_at
 FROM numbers;
 
 -- 100만 개의 stock 더미 데이터 삽입
@@ -38,9 +40,9 @@ WITH RECURSIVE numbers AS (
 )
 SELECT
     n AS product_id,
-    FLOOR(10 + RAND() * 491) AS stock,
-    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS created_at,
-    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS updated_at
+    FLOOR(10 + RAND() * 2000000) AS stock,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 300 * 24 * 3600), NOW()) AS created_at,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 300 * 24 * 3600), NOW()) AS updated_at
 FROM numbers;
 
 -- 100만 개의 product_status 더미 데이터 삽입
@@ -52,7 +54,7 @@ WITH RECURSIVE numbers AS (
 )
 SELECT
     n AS product_id,
-    FLOOR(RAND() * 3001) AS like_count,
-    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS created_at,
-    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 10 * 24 * 3600), NOW()) AS updated_at
+    FLOOR(RAND() * 2000000) AS like_count,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 300 * 24 * 3600), NOW()) AS created_at,
+    TIMESTAMPADD(SECOND, -FLOOR(RAND() * 300 * 24 * 3600), NOW()) AS updated_at
 FROM numbers;

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -37,7 +37,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
 
 datasource:
   mysql-jpa:

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -37,7 +37,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
 
 datasource:
   mysql-jpa:

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -37,7 +37,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
 
 datasource:
   mysql-jpa:

--- a/modules/redis/build.gradle.kts
+++ b/modules/redis/build.gradle.kts
@@ -14,5 +14,5 @@ repositories {
     mavenCentral()
 }
 kotlin {
-    jvmToolchain(23)
+    jvmToolchain(21)
 }

--- a/modules/redis/build.gradle.kts
+++ b/modules/redis/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    `java-library`
+    `java-test-fixtures`
+    kotlin("jvm")
+}
+
+dependencies {
+    api("org.springframework.boot:spring-boot-starter-data-redis")
+
+    testFixturesImplementation("com.redis:testcontainers-redis")
+    implementation(kotlin("stdlib-jdk8"))
+}
+repositories {
+    mavenCentral()
+}
+kotlin {
+    jvmToolchain(23)
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
@@ -1,0 +1,106 @@
+package com.loopers.config.redis;
+
+import io.lettuce.core.ReadFrom;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+@Configuration
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig {
+
+  private static final String CONNECTION_MASTER = "redisConnectionMaster";
+  public static final String REDIS_TEMPLATE_MASTER = "redisTemplateMaster";
+
+  private final RedisProperties redisProperties;
+
+  public RedisConfig(RedisProperties redisProperties) {
+    this.redisProperties = redisProperties;
+  }
+
+  @Primary
+  @Bean
+  public LettuceConnectionFactory defaultRedisConnectionFactory() {
+    var database = redisProperties.database();
+    var master = redisProperties.master();
+    var replicas = redisProperties.replicas();
+
+    return lettuceConnectionFactory(database, master, replicas,
+        builder -> builder.readFrom(ReadFrom.REPLICA_PREFERRED));
+  }
+
+  @Qualifier(CONNECTION_MASTER)
+  @Bean
+  public LettuceConnectionFactory masterRedisConnectionFactory() {
+    var database = redisProperties.database();
+    var master = redisProperties.master();
+    var replicas = redisProperties.replicas();
+
+    return lettuceConnectionFactory(database, master, replicas,
+        builder -> builder.readFrom(ReadFrom.MASTER));
+  }
+
+  @Primary
+  @Bean
+  public RedisTemplate<String, String> defaultRedisTemplate(
+      LettuceConnectionFactory lettuceConnectionFactory) {
+    return createDefaultRedisTemplate(lettuceConnectionFactory);
+  }
+
+  @Qualifier(REDIS_TEMPLATE_MASTER)
+  @Bean
+  public RedisTemplate<String, String> masterRedisTemplate(
+      @Qualifier(CONNECTION_MASTER) LettuceConnectionFactory lettuceConnectionFactory) {
+    return createDefaultRedisTemplate(lettuceConnectionFactory);
+  }
+
+  private LettuceConnectionFactory lettuceConnectionFactory(
+      int database,
+      RedisNodeInfo master,
+      List<RedisNodeInfo> replicas,
+      Consumer<LettuceClientConfiguration.LettuceClientConfigurationBuilder> customizer) {
+
+    var builder = LettuceClientConfiguration.builder();
+
+    if (customizer != null) {
+      customizer.accept(builder);
+    }
+
+    var lettuceClientConfiguration = builder.build();
+
+    var masterReplicaConfig = new RedisStaticMasterReplicaConfiguration(
+        master.host(), master.port()
+    );
+    masterReplicaConfig.setDatabase(database);
+
+    replicas.forEach(replica ->
+        masterReplicaConfig.addNode(replica.host(), replica.port())
+    );
+
+    return new LettuceConnectionFactory(masterReplicaConfig, lettuceClientConfiguration);
+  }
+
+  private RedisTemplate<String, String> createDefaultRedisTemplate(
+      LettuceConnectionFactory connectionFactory) {
+    var redisTemplate = new RedisTemplate<String, String>();
+
+    var stringSerializer = new StringRedisSerializer();
+    redisTemplate.setKeySerializer(stringSerializer);
+    redisTemplate.setValueSerializer(stringSerializer);
+    redisTemplate.setHashKeySerializer(stringSerializer);
+    redisTemplate.setHashValueSerializer(stringSerializer);
+    redisTemplate.setConnectionFactory(connectionFactory);
+
+    return redisTemplate;
+  }
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisNodeInfo.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisNodeInfo.java
@@ -1,0 +1,7 @@
+package com.loopers.config.redis;
+
+public record RedisNodeInfo(
+    String host,
+    int port
+) {
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisProperties.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisProperties.java
@@ -1,0 +1,12 @@
+package com.loopers.config.redis;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(value = "datasource.redis")
+public record RedisProperties(
+    int database,
+    RedisNodeInfo master,
+    List<RedisNodeInfo> replicas
+) {
+}

--- a/modules/redis/src/main/resources/redis.yml
+++ b/modules/redis/src/main/resources/redis.yml
@@ -1,0 +1,36 @@
+spring:
+  data:
+    redis:
+      repositories:
+        enabled: false
+
+datasource:
+  redis:
+    database: 0
+    master:
+      host: ${REDIS_MASTER_HOST}
+      port: ${REDIS_MASTER_PORT}
+    replicas:
+      - host: ${REDIS_REPLICA_1_HOST}
+        port: ${REDIS_REPLICA_1_PORT}
+
+---
+spring.config.activate.on-profile: local, test
+
+datasource:
+  redis:
+    master:
+      host: localhost
+      port: 6379
+    replicas:
+      - host: localhost
+        port: 6380
+
+---
+spring.config.activate.on-profile: dev
+
+---
+spring.config.activate.on-profile: qa
+
+---
+spring.config.activate.on-profile: prd

--- a/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
@@ -9,7 +9,7 @@ public class RedisTestContainersConfig {
   private static final GenericContainer<?> redisContainer;
 
   static {
-    redisContainer = new GenericContainer<>("redis:latest");
+    redisContainer = new GenericContainer<>("redis:latest").withExposedPorts(6379);
     redisContainer.start();
   }
 

--- a/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
@@ -1,0 +1,23 @@
+package com.loopers.testcontainers;
+
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
+
+@Configuration
+public class RedisTestContainersConfig {
+
+  private static final GenericContainer<?> redisContainer;
+
+  static {
+    redisContainer = new GenericContainer<>("redis:latest");
+    redisContainer.start();
+  }
+
+  public RedisTestContainersConfig() {
+    System.setProperty("datasource.redis.database", "0");
+    System.setProperty("datasource.redis.master.host", redisContainer.getHost());
+    System.setProperty("datasource.redis.host.port", String.valueOf(redisContainer.getFirstMappedPort()));
+    System.setProperty("datasource.redis.replicas[0].host", redisContainer.getHost());
+    System.setProperty("datasource.redis.replicas[0].port", String.valueOf(redisContainer.getFirstMappedPort()));
+  }
+}

--- a/modules/redis/src/testFixtures/java/com/loopers/utils/RedisCleanUp.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/utils/RedisCleanUp.java
@@ -1,0 +1,20 @@
+package com.loopers.utils;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisCleanUp {
+
+  private final RedisConnectionFactory redisConnectionFactory;
+
+  public RedisCleanUp(RedisConnectionFactory redisConnectionFactory) {
+    this.redisConnectionFactory = redisConnectionFactory;
+  }
+
+  public void truncateAll() {
+    try (var connection = redisConnectionFactory.getConnection()) {
+      connection.serverCommands().flushAll();
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "dragon_e-commerce"
 include(
     ":apps:commerce-api",
     ":modules:jpa",
+    ":modules:redis",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",
@@ -10,8 +11,10 @@ include(
 
 // configurations
 pluginManagement {
+    val kotlinVersion: String by settings
     val springBootVersion: String by settings
     val springDependencyManagementVersion: String by settings
+    val ktLintPluginVersion: String by settings
 
     repositories {
         maven { url = uri("https://repo.spring.io/milestone") }
@@ -22,9 +25,20 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             when (requested.id.id) {
+                "org.jetbrains.kotlin.jvm" -> useVersion(kotlinVersion)
+                "org.jetbrains.kotlin.kapt" -> useVersion(kotlinVersion)
+                "org.jetbrains.kotlin.plugin.spring" -> useVersion(kotlinVersion)
+                "org.jetbrains.kotlin.plugin.jpa" -> useVersion(kotlinVersion)
                 "org.springframework.boot" -> useVersion(springBootVersion)
                 "io.spring.dependency-management" -> useVersion(springDependencyManagementVersion)
+                "org.jlleitschuh.gradle.ktlint" -> useVersion(ktLintPluginVersion)
             }
         }
     }
+    plugins {
+        kotlin("jvm") version "2.1.21"
+    }
+}
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }


### PR DESCRIPTION
## 📌 Summary
1. 데이터 세팅(100만 건)
2. 인덱스 추가(인덱스는 모델에서 하지 않구 DB에 직접 넣었습니다.)
3. 캐시 적용 (좋아요 인기 순위 탑 10)

## 💬 Review Points
1. 캐시 키 관리
   - 레디스에서 캐시 정보를 가져올때, 캐시 정보를 지울때등등 여러 부분(
   api에서 warm up,
   캐시 데이터 가져오는
   스케쥴링에서 warm up)에서, 같은 키가 여러군대에 작성 되어 있어서 어떻게 관리를 해야 할지 고민이 되어집니다. 

2. TTL, 스케쥴링 시간
    현재는 TTL이 10분으로 작성되어 있고 스케쥴링은 5분으로 설정되어 있습니다. 그 이유는 스케쥴링이 5분마다 돌면서 TTL을 초기화 시키면 
    지속적으로 사용할 수 있을거 같아 TTL은 10분 스케쥴링은 5분으로 설정하였습니다. 지금 생각해보니 인기 순위를 캐싱하기 때문에 시간은   
    1일 정도로 해도 될거 같다라는 생각이 들었습니다. 제가 궁금한건 이 둘의 시간을 어떻게 지정을 하면 좋을지 궁금합니다. 사용자가 사용할때
   서비스가 같은 속도로? 사용할 수 있게 해주면 되는 걸까요?


## ✅ Checklist
### 🔖 Index
- #52 
- [X]  상품 목록 API에서 brandId 기반 검색, 좋아요 순 정렬 등을 처리했다.
- [X]  조회 필터, 정렬 조건별 유즈케이스를 분석하여 인덱스를 적용하고 전 후 성능비교를 진행했다. (Optional 카디널리티 분석)

### ❤️ Structure
- [X]  상품 목록/상세 조회 시 좋아요 수를 조회 및 좋아요 순 정렬이 가능하도록 구조 개선을 진행했다.
- [X]  좋아요 적용/해제 진행 시 상품 좋아요 수 또한 정상적으로 동기화되도록 진행하였다.

### ⚡ Cache 
- #53  
- [X]  Redis 캐시를 적용하고 TTL 또는 무효화 전략을 적용했다. 
- [X]  캐시 미스 상황에서도 서비스가 정상 동작하도록 처리했다.